### PR TITLE
Exercise Module Updates

### DIFF
--- a/config/template.ini
+++ b/config/template.ini
@@ -107,8 +107,8 @@ device_control_method = uiautomator2
 combat_screenshot_interval = 1.
 enable_update_check = no
 update_method = api
-update_proxy = 
-github_token = 
+update_proxy =
+github_token =
 
 [Daily]
 enable_daily_mission = yes
@@ -187,6 +187,7 @@ daily = 2020-01-01_00:00:00
 hard = 2020-01-01_00:00:00
 exercise = 2020-01-01_00:00:00
 raid = 2020-01-01_00:00:00
+exercise_count = 0
 
 [EventABRecord]
 a1 = 2020-01-01_00:00:00

--- a/module/config/argparser_en.py
+++ b/module/config/argparser_en.py
@@ -296,7 +296,7 @@ def main(ini_name=''):
 
     # 演习设置
     exercise = daily_parser.add_argument_group('Exercise settings', 'Only support the most experience for the time being')
-    exercise.add_argument('--exercise_choose_mode', default=default('--exercise_choose_mode'), choices=['max_exp', 'max_ranking', 'good_opponent', 'easiest'], help='Only support the most experience for the time being')
+    exercise.add_argument('--exercise_choose_mode', default=default('--exercise_choose_mode'), choices=['max_exp', 'max_ranking', 'good_opponent', 'easiest', 'easiest_else_exp'], help='Only support the most experience for the time being')
     exercise.add_argument('--exercise_preserve', default=default('--exercise_preserve'), help='Only 0 are temporarily reserved')
     exercise.add_argument('--exercise_try', default=default('--exercise_try'), help='The number of attempts by each opponent')
     exercise.add_argument('--exercise_hp_threshold', default=default('--exercise_hp_threshold'), help='HHP <Retreat at Threshold')

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -694,6 +694,58 @@ class AzurLaneConfig:
         self.config.set(option[0], option[1], record)
         self.save()
 
+    def record_save_zero(self, option):
+        """
+            Note:
+                Save an entry of now's date but with 0 time
+                to allow re-runs for example DailyRecord exercise
+
+            option (tuple(str)): (Section, Option), such as ('DailyRecord', 'exercise').
+        """
+        date = datetime.now().replace(hour=0, minute=0, second=0)
+        record = datetime.strftime(date, self.TIME_FORMAT)
+        self.config.set(option[0], option[1], record)
+        self.save()
+
+    def record_day_check(self):
+        """
+        Note:
+            Really only applies to daily record exercise, so using constant
+
+        Returns:
+            int: An opponent_change_count based on configuration or current date
+        """
+        RECORD_OPTION = ('DailyRecord', 'exercise')
+        RECORD_SINCE = (0, 12, 18,)
+        RECORD_COUNT = ('DailyRecord', 'exercise_count')
+        record = datetime.strptime(self.config.get(*RECORD_OPTION), self.TIME_FORMAT)
+        update = self.get_server_last_update(RECORD_SINCE)
+        if record.date() == update.date():
+            logger.hr("Same Day")
+            return self.config.getint(*RECORD_COUNT, fallback=6)
+        else:
+            logger.hr("New Day")
+            return 0
+
+    def record_change_count(self, value):
+        """
+        Note:
+            Really only applies to daily record exercise, so using constant
+
+            Args:
+                value (int): This value should strictly be positive int
+        """
+        RECORD_COUNT = ('DailyRecord', 'exercise_count')
+        try:
+            value = int(value)
+            if value < 0:
+                raise
+            logger.hr("Saving Opponent Change Count")
+            self.config.set('DailyRecord', 'exercise_count', str(value))
+            self.save()
+        except:
+            logger.hr("Unable to save Opponent Change Count")
+
     def __init__(self, ini_name='alas'):
         """
         Args:

--- a/module/exercise/exercise.py
+++ b/module/exercise/exercise.py
@@ -11,25 +11,52 @@ RECORD_SINCE = (0, 12, 18,)
 
 class Exercise(ExerciseCombat):
     opponent_change_count = 0
+    remain = 0
 
     def _new_opponent(self):
         logger.info('New opponent')
         self.appear_then_click(NEW_OPPONENT)
         self.opponent_change_count += 1
-        self.device.sleep(1)
+        self.device.sleep(6)
 
     def _exercise_once(self):
-        while self.opponent_change_count <= 5:
-            self._opponent_fleet_check_all()
-            for opponent in self._opponent_sort():
-                success = self._combat(opponent)
-                if success:
-                    return success
+        self._opponent_fleet_check_all()
+        for opponent in self._opponent_sort():
+            success = self._combat(opponent)
+            if success:
+                return success
+        if self.opponent_change_count <= 5:
             self._new_opponent()
-            self._opponent_fleet_check_all()
+            return True
         return False
 
+    def _exercise_easiest_else_exp(self):
+        restore = 0
+        self._opponent_fleet_check_all()
+        while 1:
+            opponents = self._opponent_sort()
+            success = self._combat(opponents[0])
+            if success:
+                self.config.EXERCISE_CHOOSE_MODE = "easiest_else_exp"
+                self.config.LOW_HP_THRESHOLD = restore if not self.config.LOW_HP_THRESHOLD else self.config.LOW_HP_THRESHOLD
+                return success
+            else:
+                if self.opponent_change_count <= 5:
+                    logger.info("Cannot beat calculated easiest opponent, refresh!")
+                    self._new_opponent()
+                    return True
+                else:
+                    logger.info("Cannot beat calculated easiest opponent, MAX EXP then!")
+                    self.config.EXERCISE_CHOOSE_MODE = "max_exp"
+                    restore = self.config.LOW_HP_THRESHOLD
+                    self.config.LOW_HP_THRESHOLD = 0
+
     def run(self):
+        # Same day, count set to last known change count or 6 i.e. no refresh
+        # New day, count set to 0 i.e. can change up to 5 times
+        self.opponent_change_count = self.config.record_day_check()
+        logger.info("Change Opponent Count: {}".format(self.opponent_change_count))
+
         self.ui_ensure(page_exercise)
         # self.equipment_take_on()
         # self.device.sleep(1)
@@ -37,12 +64,15 @@ class Exercise(ExerciseCombat):
         logger.hr('Exercise', level=1)
         while 1:
             self.device.screenshot()
-            remain = OCR_EXERCISE_REMAIN.ocr(self.device.image)
-            if remain == 0:
+            self.remain = OCR_EXERCISE_REMAIN.ocr(self.device.image)
+            if self.remain == 0:
                 break
 
-            logger.hr('Remain: %s' % remain)
-            success = self._exercise_once()
+            logger.hr('Remain: %s' % self.remain)
+            if self.config.EXERCISE_CHOOSE_MODE == "easiest_else_exp":
+                success = self._exercise_easiest_else_exp()
+            else:
+                success = self._exercise_once()
             if not success:
                 logger.info('New opponent exhausted')
                 break
@@ -53,4 +83,8 @@ class Exercise(ExerciseCombat):
         return self.config.record_executed_since(option=RECORD_OPTION, since=RECORD_SINCE)
 
     def record_save(self):
-        return self.config.record_save(option=RECORD_OPTION)
+        self.config.record_change_count(value=self.opponent_change_count)
+        if not self.remain:
+            return self.config.record_save(option=RECORD_OPTION)
+        else:
+            return self.config.record_save_zero(option=RECORD_OPTION)

--- a/module/exercise/opponent.py
+++ b/module/exercise/opponent.py
@@ -65,7 +65,7 @@ class Opponent:
         # power = np.sum(self.power) / 6
         # return level - (power - 1000) / 30
 
-        if method == "easiest":
+        if "easiest" in method:
             level = (1 - (np.sum(self.level) / MAX_LVL_SUM)) * 100
             team_pwr_div = np.count_nonzero(self.level) * PWR_FACTOR
             avg_team_pwr = np.sum(self.power) / team_pwr_div


### PR DESCRIPTION
Revamped exercise to use date, configurations, and opponent_change_count.  Added several helper methods to save data as needed and allow re-runs of exercise if needed. Added new mode 'easiest_else_exp' and exclusive method for mode as this performs exactly two rounds of pvp then moves onto to the next change in 4 opponents. Just as it describes, if unable to beat easiest opponent then switch to max exp opponent and accept the loss. Both _exercise_once and _excercise_easiest_else_exp have been tested and seem to be behaving correctly under the revamped exercise implementation.