### PR TITLE
bugfix exercise module, check all opponents using old image possibly …

### DIFF
--- a/module/exercise/exercise.py
+++ b/module/exercise/exercise.py
@@ -25,7 +25,7 @@ class Exercise(ExerciseCombat):
         self.config.config.set(*RECORD_COUNT, str(self.opponent_change_count))
         self.config.save()
 
-        self.ensure_no_info_bar()
+        self.ensure_no_info_bar(timeout=3)
 
     def _exercise_once(self):
         """Execute exercise once.


### PR DESCRIPTION
…an issue with its info bar not matching to asset, instead relying on timer with 3 seconds instead of the default 0.6. 5/5 tries in between refreshes the image being scanned is correctly being reflected for calculations