### PR TITLE
fix regexp for durations using two digits namely '12'. It would incor…

### DIFF
--- a/module/research/project.py
+++ b/module/research/project.py
@@ -20,7 +20,7 @@ FILTER_REGEX = re.compile('(s[123])?'
                           '(dr|pry)?'
                           '([bcdeghqt])?'
                           '-?'
-                          '(\d.\d|\d)?')
+                          '(\d.\d|\d\d?)?')
 FILTER_ATTR = ('series', 'ship', 'ship_rarity', 'genre', 'duration')
 FILTER_PRESET = ('shortest', 'cheapest', 'reset')
 FILTER = Filter(FILTER_REGEX, FILTER_ATTR, FILTER_PRESET)
@@ -174,7 +174,9 @@ class ResearchSelector(UI):
 
         FILTER.load(string)
         priority = FILTER.apply(self.projects)
+        logger.info(priority)
         priority = self._research_check_filter(priority)
+        logger.info(priority)
 
         # Log
         logger.attr(

--- a/module/research/project.py
+++ b/module/research/project.py
@@ -174,9 +174,7 @@ class ResearchSelector(UI):
 
         FILTER.load(string)
         priority = FILTER.apply(self.projects)
-        logger.info(priority)
         priority = self._research_check_filter(priority)
-        logger.info(priority)
 
         # Log
         logger.attr(


### PR DESCRIPTION
…rectly capture only the 1 in C12 and when filtered did not match the duration attribute as a result thus was not filtered correctly. If there are double digits using decimal places (12.5) then the regexp will need to be updated again but for time being this works for properly for 12 hour filters

Sample debug output from printing in the apply_filter_to_obj various strings that can be printed
2020-07-30 16:54:04.257 | INFO | [None, None, None, 'c', '1']
2020-07-30 16:54:04.258 | INFO | S3 C-038-RF
2020-07-30 16:54:04.258 | INFO | duration
2020-07-30 16:54:04.258 | INFO | 1
2020-07-30 16:54:04.258 | INFO | 12

The value is 1 because it only captured C1 from C12, it should however capture 12 so that this conditional passes in the filter.