### PR TITLE
Fix: Log charset set to UTF-8

### DIFF
--- a/module/logger.py
+++ b/module/logger.py
@@ -39,10 +39,10 @@ if '_' in pyw_name:
     pyw_name = '_'.join(pyw_name.split('_')[:-1])
 log_file = f'./log/{datetime.date.today()}_{pyw_name}.txt'
 try:
-    file = logging.FileHandler(log_file)
+    file = logging.FileHandler(log_file, encoding='utf-8')
 except FileNotFoundError:
     os.mkdir('./log')
-    file = logging.FileHandler(log_file)
+    file = logging.FileHandler(log_file, encoding='utf-8')
 file.setFormatter(formatter)
 logger.addHandler(file)
 


### PR DESCRIPTION
The default character encoding of "logging" is cp1252, which is not able to encode CJK chars.
Commission names in JP server (maybe also CN server) could cause logging errors like this:
`2020-09-15 19:55:53.839 | INFO | 上級資材整理 (Genre: major_comm, Status: pending, Duration: 10:00:00)`
`--- Logging error ---`
`Traceback (most recent call last):`
`  File "D:\Program\AzurLaneAutoScript\toolkit\lib\logging\__init__.py", line 1028, in emit`
`    stream.write(msg + self.terminator)`
`  File "D:\Program\AzurLaneAutoScript\toolkit\lib\encodings\cp1252.py", line 19, in encode`
`    return codecs.charmap_encode(input,self.errors,encoding_table)[0]`
`UnicodeEncodeError: 'charmap' codec can't encode characters in position 33-38: character maps to <undefined>`
`Call stack:`
`  File "alas_jp.pyw", line 8, in <module>`
`    main()`
`  File "D:\Program\AzurLaneAutoScript\toolkit\lib\site-packages\gooey\python_bindings\gooey_decorator.py", line 130, in <lambda>`
`    return lambda *args, **kwargs: func(*args, **kwargs)`
`  File "D:\Program\AzurLaneAutoScript\module\config\argparser_jp.py", line 461, in main`
`    alas.run(command=command)`
`  File "D:\Program\AzurLaneAutoScript\alas.py", line 27, in run`
`    self.__getattribute__(command.lower())()`
`  File "D:\Program\AzurLaneAutoScript\alas.py", line 171, in c72_mystery_farming`
`    self.reward_when_finished()`
`  File "D:\Program\AzurLaneAutoScript\alas.py", line 73, in reward_when_finished`
`    az.reward_loop()`
`  File "D:\Program\AzurLaneAutoScript\module\reward\reward.py", line 190, in reward_loop`
`    self.reward()`
`  File "D:\Program\AzurLaneAutoScript\module\reward\reward.py", line 51, in reward`
`    self.handle_commission_start()`
`  File "D:\Program\AzurLaneAutoScript\module\reward\commission.py", line 677, in handle_commission_start`
`    self.commission_start()`
`  File "D:\Program\AzurLaneAutoScript\module\reward\commission.py", line 641, in commission_start`
`    self._commission_scan_all()`
`  File "D:\Program\AzurLaneAutoScript\module\reward\commission.py", line 551, in _commission_scan_all`
`    logger.info(comm)`
`Message: <module.reward.commission.Commission object at 0x0000020457F2FBC8>`
