### PR TITLE
Fix: Error log char encoding set to UTF-8

### DIFF
--- a/alas.py
+++ b/alas.py
@@ -56,15 +56,15 @@ class AzurLaneAutoScript:
                 image_time = datetime.strftime(data['time'], '%Y-%m-%d_%H-%M-%S-%f')
                 image = handle_sensitive_image(data['image'])
                 image.save(f'{folder}/{image_time}.png')
-            with open(log_file, 'r') as f:
+            with open(log_file, 'r', encoding='utf-8') as f:
                 start = 0
                 for index, line in enumerate(f.readlines()):
                     if re.search('\+-{15,}\+', line):
                         start = index
-            with open(log_file, 'r') as f:
+            with open(log_file, 'r', encoding='utf-8') as f:
                 text = f.readlines()[start - 2:]
                 text = handle_sensitive_logs(text)
-            with open(f'{folder}/log.txt', 'w') as f:
+            with open(f'{folder}/log.txt', 'w', encoding='utf-8') as f:
                 f.writelines(text)
 
     def reward_when_finished(self):


### PR DESCRIPTION
82277e3d5a9878a2204b178bb24ccfa94a839974 changed log char encoding to UTF-8 and it broke 'save_error_log'.