### PR TITLE
Fix: click tactical book button multiple times

### DIFF
--- a/module/reward/tactical_class.py
+++ b/module/reward/tactical_class.py
@@ -192,8 +192,9 @@ class RewardTacticalClass(UI):
                             exp=self.config.TACTICAL_EXP_FIRST)
 
         if book is not None:
-            self.device.click(book.button)
-            self.device.sleep((0.3, 0.5))
+            for _ in range(3):
+                self.device.click(book.button)
+                self.device.sleep((0.3, 0.5))
             self.device.click(TACTICAL_CLASS_START)
         else:
             # cancel_tactical, use_the_first_book


### PR DESCRIPTION
We do not have a check to confirm that the book is selected correctly. If the game show no response to the click (it is usual on slow pc), the first book will be selected. Clicking the button multiple times to reduce the possibility of wrong selection.