### PR TITLE
Opt: reward receiving logic optimization

### DIFF
--- a/module/research/research.py
+++ b/module/research/research.py
@@ -341,11 +341,12 @@ class RewardResearch(ResearchSelector):
         if not self.config.ENABLE_RESEARCH_REWARD:
             return False
 
-        if not self.appear(RESEARCH_FINISHED) and not self.appear(RESEARCH_PENDING, offset=(20, 20)):
-            logger.info('No research finished or pending')
+        if not self.appear(RESEARCH_PENDING, offset=(20, 20)):
+            logger.info('No research pending')
             return False
 
         self.ui_ensure_research()
         self.research_reward()
 
+        self.ui_goto(page_reward, skip_first_screenshot=True)
         return True

--- a/module/reward/reward.py
+++ b/module/reward/reward.py
@@ -46,11 +46,21 @@ class Reward(RewardCommission, RewardTacticalClass, RewardResearch, RewardMeowff
         self.ui_goto_main()
 
         self.ui_goto(page_reward, skip_first_screenshot=True)
-        self._reward_receive()
-        self.handle_info_bar()
-        self.handle_commission_start()
-        self.handle_tactical_class()
-        self.handle_research_reward()
+
+        reward_handled = False
+        while 1:
+            if reward_handled:
+                break
+            self._reward_receive()
+            self.handle_info_bar()
+            if self.handle_commission_start():
+                continue
+            if self.handle_tactical_class():
+                continue
+            if self.handle_research_reward():
+                continue
+            reward_handled = True
+
         self.ui_goto(page_main, skip_first_screenshot=True)
 
         self.handle_meowfficer()

--- a/module/reward/tactical_class.py
+++ b/module/reward/tactical_class.py
@@ -285,6 +285,4 @@ class RewardTacticalClass(UI):
         if not self.config.ENABLE_TACTICAL_REWARD:
             return False
 
-        self._tactical_class_receive()
-
-        return True
+        return self._tactical_class_receive()


### PR DESCRIPTION
To ensure that nothing is pending before exiting page_reward. It also avoids using research_receive() function in RewardResearch class which might be unstable because of too many sleep().