### PR TITLE
Opt: normalize before calculation in hp balancer

### DIFF
--- a/module/combat/hp_balancer.py
+++ b/module/combat/hp_balancer.py
@@ -122,6 +122,7 @@ class HPBalancer(ModuleBase):
     def _expected_scout_order(self, hp):
         count = np.count_nonzero(hp)
         threshold = self.config.SCOUT_HP_DIFFERENCE_THRESHOLD
+        hp = np.array(hp) / max(hp)
 
         if count == 3:
             descending = np.sort(hp)[::-1]


### PR DESCRIPTION
To avoid sth strange like: threshold = 0.2, hp = [0.05, 0.2, 0], no reposition.