### PR TITLE
Fix: sos clear potential boss stuck due to default FLEET_BOSS=2

### DIFF
--- a/module/sos/sos.py
+++ b/module/sos/sos.py
@@ -145,7 +145,7 @@ class CampaignSos(CampaignRun, CampaignBase):
             if not self._sos_is_appear_at_chapter(chapter):
                 continue
 
-            backup = self.config.cover(FLEET_1=fleet_1, FLEET_2=fleet_2, SUBMARINE=submarine)
+            backup = self.config.cover(FLEET_1=fleet_1, FLEET_2=fleet_2, SUBMARINE=submarine, FLEET_BOSS=1 if not fleet_2 else 2)
             super().run(f'campaign_{chapter}_5', folder=folder, total=total)
             backup.recover()
 


### PR DESCRIPTION
relevant for fleet_2 = 0

Alternatively, can consider re-work the `fleet_boss` method itself but due to relation with other modules, difficult to determine overall impact may cause. Chose config backup method for quick easy resolution.

```
    @property
    def fleet_boss(self):
        if self.config.FLEET_BOSS == 2 or self.config.FLEET_2:
            return self.fleet_2
        else:
            return self.fleet_1
```