### PR TITLE
Fix: On first round, often same ship is detected as new ship

### DIFF
--- a/module/equipment/equipment.py
+++ b/module/equipment/equipment.py
@@ -21,6 +21,7 @@ class Equipment(UI):
         swipe_timer = Timer(5, count=10)
         self.ensure_no_info_bar(timeout=3)
         SWIPE_CHECK.load_color(self.device.image)
+        SWIPE_CHECK._match_init = True # Disable ensure_template() on match(), allows ship to be properly determined whether different or not
         while 1:
             if not swipe_timer.started() or swipe_timer.reached():
                 swipe_timer.reset()
@@ -32,7 +33,7 @@ class Equipment(UI):
             self.device.screenshot()
             if SWIPE_CHECK.match(self.device.image):
                 if swipe_count > 1:
-                    logger.warning('Same ship on multiple swipes')
+                    logger.info('Same ship on multiple swipes')
                     return False
                 continue
 


### PR DESCRIPTION
Disabling ensure_template repairs this behavior and retains
if new ship is actually detected

Used a custom script debugger to run through simulated scenarios in this case when enhancing and swiping
[module_check.zip](https://github.com/LmeSzinc/AzurLaneAutoScript/files/5745031/module_check.zip)

Removing that flag setting in equipment.py, will result in the problematic scenario in which the first swipe, if there are no adjacent ships, then it will think its a new ship anyway and the second swipe will properly detect.  Apparently on the first swipe, it is 0% similarity according to match(), not entirely sure why but just an observation.
