### PR TITLE
Fix: Additional raise clause for method

### DIFF
--- a/campaign/event_20200917_cn/campaign_base.py
+++ b/campaign/event_20200917_cn/campaign_base.py
@@ -75,6 +75,8 @@ class CampaignBase(CampaignBase_):
                 return 1
             elif name in ['b', 'd']:
                 return 2
+            else:
+                raise CampaignNameError
 
     def _campaign_ball_get(self):
         """

--- a/campaign/event_20201029_cn/campaign_base.py
+++ b/campaign/event_20201029_cn/campaign_base.py
@@ -30,6 +30,8 @@ class CampaignBase(CampaignBase_):
                 return 1
             elif name in ['b', 'd', 'ex_sp']:  # Difference
                 return 2
+            else:
+                raise CampaignNameError
 
     def campaign_set_chapter(self, name, mode='normal'):
         """

--- a/campaign/event_20201126_cn/campaign_base.py
+++ b/campaign/event_20201126_cn/campaign_base.py
@@ -33,6 +33,8 @@ class CampaignBase(CampaignBase_):
                 return 1
             elif name in ['b', 'd', 'ex_sp']:  # Difference
                 return 2
+            else:
+                raise CampaignNameError
 
     def campaign_set_chapter(self, name, mode='normal'):
         """

--- a/module/campaign/campaign_ocr.py
+++ b/module/campaign/campaign_ocr.py
@@ -32,6 +32,8 @@ class CampaignOcr(ModuleBase):
                 return 1
             elif name in ['b', 'd', 'ex_ex']:
                 return 2
+            else:
+                raise CampaignNameError
 
     @staticmethod
     def _campaign_ocr_result_process(result):

--- a/module/guild/operations.py
+++ b/module/guild/operations.py
@@ -322,7 +322,7 @@ class GuildOperations(GuildBase):
         if operations_mode == 0:
             return
         elif operations_mode == 1:
-            # Limit check for scanning operations to 4 times a day i.e. 6-hour intervals
+            # Limit check for scanning operations to 4 times a day i.e. 6-hour intervals, 4th time reduced to 3-hour
             if not self.config.record_executed_since(option=RECORD_OPTION_DISPATCH, since=RECORD_SINCE_DISPATCH):
                 self._guild_operations_scan()
                 self.config.record_save(option=RECORD_OPTION_DISPATCH)
@@ -331,8 +331,9 @@ class GuildOperations(GuildBase):
             if not self.config.record_executed_since(option=RECORD_OPTION_BOSS, since=RECORD_SINCE_BOSS):
                 skip_record = False
                 if self.appear(GUILD_BOSS_AVAILABLE):
-                    if self.config.ENABLE_GUILD_OPERATIONS_BOSS_AUTO and not self._guild_operations_boss_combat():
-                        skip_record = True
+                    if self.config.ENABLE_GUILD_OPERATIONS_BOSS_AUTO:
+                        if not self._guild_operations_boss_combat():
+                            skip_record = True
                     else:
                         logger.info('Auto-battle disabled, play manually to complete this Guild Task')
 


### PR DESCRIPTION
This was added in the case ocr resulted in an unexpected stage name that did not belong in any list.  Applied same principal to other counterparts should a rerun happen in the near future.

Fix: Invalid place for 'and' operator, the else clause should not have executed in case the combat was successful, lack of testing on my part.