### PR TITLE
Fix: GET_ITEMS_1 raises MapDetectionError

### DIFF
--- a/module/map/camera.py
+++ b/module/map/camera.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from module.combat.assets import GET_ITEMS_1
 from module.exception import MapDetectionError, CampaignEnd
 from module.handler.assets import IN_MAP, GAME_TIPS
 from module.logger import logger
@@ -97,6 +98,10 @@ class Camera(MapOperation):
             if self.info_bar_count():
                 logger.info('Perspective error cause by info bar. Waiting.')
                 self.handle_info_bar()
+                return self.update(camera=camera)
+            elif self.appear(GET_ITEMS_1):
+                logger.warning('Items got. Trying handling mystery.')
+                self.handle_mystery()
                 return self.update(camera=camera)
             elif self.is_in_stage():
                 logger.warning('Image is in stage')


### PR DESCRIPTION
It was a quite rare case.
The emulator sometimes treat a swipe as a click (mostly on potato pcs). If this happens while doing map_swipe(), the fleet might step on a mystery, then GET_ITEMS_1 would raise MapDetectionError.
Here is the error log:
```
2021-02-11 07:56:12.213 | INFO | Map swipe: (0, 1)
2021-02-11 07:56:12.213 | INFO | Swipe ( 719,  484) -> ( 717,  344), 0.167
2021-02-11 07:56:13.053 | INFO |            tile_center: 0.615 (bad match)
2021-02-11 07:56:13.251 | INFO |            tile_corner: 0.750 (bad match)
2021-02-11 07:56:13.350 | INFO |         tile_rectangle: 0 rectangles (bad match)
2021-02-11 07:56:13.353 | WARNING | Image to detect is not in_map
2021-02-11 07:56:13.354 | ERROR | Failed to find a free tile
Traceback (most recent call last):
  File "C:\fakepath\AzurLaneAutoScript\alas.py", line 28, in run
    self.__getattribute__(command.lower())()
  File "C:\fakepath\AzurLaneAutoScript\alas.py", line 195, in c72_mystery_farming
    az.run('campaign_7_2_mystery_farming')
  File "C:\fakepath\AzurLaneAutoScript\module\campaign\run.py", line 233, in run
    self.campaign.run()
  File "C:\fakepath\AzurLaneAutoScript\module\campaign\campaign_base.py", line 139, in run
    self.execute_a_battle()
  File "C:\fakepath\AzurLaneAutoScript\module\campaign\campaign_base.py", line 96, in execute_a_battle
    result = self.battle_function()
  File "C:\fakepath\AzurLaneAutoScript\module\base\decorator.py", line 63, in wrapper
    return record['func'](self, *args, **kwargs)
  File "C:\fakepath\AzurLaneAutoScript\module\campaign\campaign_base.py", line 86, in battle_function
    result = func()
  File "C:\fakepath\AzurLaneAutoScript\campaign\campaign_main\campaign_7_2_mystery_farming.py", line 157, in battle_0
    if self.clear_grids_for_faster(GRIDS_FOR_FASTER, scale=(3,), genre=['enemy', 'light', 'treasure']):
  File "C:\fakepath\AzurLaneAutoScript\module\map\map.py", line 281, in clear_grids_for_faster
    self.clear_chosen_enemy(grids[0])
  File "C:\fakepath\AzurLaneAutoScript\module\map\map.py", line 22, in clear_chosen_enemy
    self.full_scan()
  File "C:\fakepath\AzurLaneAutoScript\module\map\fleet.py", line 378, in full_scan
    siren_count=self.siren_count, carrier_count=self.carrier_count, mode=mode)
  File "C:\fakepath\AzurLaneAutoScript\module\map\camera.py", line 253, in full_scan
    self.focus_to(queue[0])
  File "C:\fakepath\AzurLaneAutoScript\module\map\camera.py", line 216, in focus_to
    self.map_swipe(tuple(sign * swipe))
  File "C:\fakepath\AzurLaneAutoScript\module\map\camera.py", line 57, in map_swipe
    self._map_swipe(vector)
  File "C:\fakepath\AzurLaneAutoScript\module\map\camera.py", line 39, in _map_swipe
    self.update()
  File "C:\fakepath\AzurLaneAutoScript\module\map\camera.py", line 111, in update
    raise e
  File "C:\fakepath\AzurLaneAutoScript\module\map\camera.py", line 95, in update
    self.view.load(self.device.image)
  File "C:\fakepath\AzurLaneAutoScript\module\map_detection\view.py", line 53, in load
    super().load(image)
  File "C:\fakepath\AzurLaneAutoScript\module\map_detection\detector.py", line 49, in load
    self.backend.load(image)
  File "C:\fakepath\AzurLaneAutoScript\module\map_detection\homography.py", line 81, in load
    self.detect(image)
  File "C:\fakepath\AzurLaneAutoScript\module\map_detection\homography.py", line 172, in detect
    raise MapDetectionError('Failed to find a free tile')
module.exception.MapDetectionError: Failed to find a free tile
```