### PR TITLE
fix: fix campaign autosearch ignore low emotion stuck

### DIFF
--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -168,6 +168,6 @@ class AutoSearchCombat(Combat):
 
         self.device.stuck_record_clear()
         self.auto_search_combat_execute(emotion_reduce=emotion_reduce, fleet_index=fleet_index)
-        self.auto_search_combat_status()
+        self.auto_search_combat_status(save_get_items=save_get_items)
 
         logger.info('Combat end.')

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -119,18 +119,34 @@ class AutoSearchCombat(Combat):
                 self.device.screenshot_interval_set(0)
                 break
 
-    def auto_search_combat_status(self, skip_first_screenshot=True):
+    def auto_search_combat_status(self, save_get_items=False, skip_first_screenshot=True):
         """
         Pages:
             in: any
             out: is_auto_search_running()
         """
         logger.info('Auto Search combat status')
+        exp_info = False  # This is for the white screen bug in game
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
             else:
                 self.device.screenshot()
+
+            # Combat status
+            if not exp_info and self.handle_get_ship(save_get_items=save_get_items):
+                continue
+            if self.handle_get_items(save_get_items=save_get_items):
+                continue
+            if self.handle_battle_status(save_get_items=save_get_items):
+                continue
+            if self.handle_popup_confirm():
+                continue
+            if self.handle_exp_info():
+                exp_info = True
+                continue
+            if self.handle_auto_search_map_option():
+                continue
 
             # End
             if self.is_auto_search_running():
@@ -140,7 +156,7 @@ class AutoSearchCombat(Combat):
             if self._handle_auto_search_menu_missing():
                 raise CampaignEnd
 
-    def auto_search_combat(self, emotion_reduce=None, fleet_index=1):
+    def auto_search_combat(self, emotion_reduce=None, save_get_items=None, fleet_index=1):
         """
         Execute a combat.
 
@@ -148,6 +164,7 @@ class AutoSearchCombat(Combat):
         It's not the fleet index in fleet preparation or auto search setting.
         """
         emotion_reduce = emotion_reduce if emotion_reduce is not None else self.config.ENABLE_EMOTION_REDUCE
+        save_get_items = save_get_items if save_get_items is not None else self.config.ENABLE_SAVE_GET_ITEMS
 
         self.device.stuck_record_clear()
         self.auto_search_combat_execute(emotion_reduce=emotion_reduce, fleet_index=fleet_index)

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -145,6 +145,13 @@ class AutoSearchCombat(Combat):
             if self.handle_exp_info():
                 exp_info = True
                 continue
+            if self.handle_urgent_commission(save_get_items=save_get_items):
+                continue
+            if self.handle_story_skip():
+                continue
+            if self.handle_guild_popup_cancel():
+                self.config.GUILD_POPUP_TRIGGERED = True
+                continue
             if self.handle_auto_search_map_option():
                 continue
 


### PR DESCRIPTION
When `IGNORE_LOW_EMOTION_WARN` is true and the campaign run is using autosearch, ALAS will ignore the popup as intended.

However, by ignoring this popup, Azur Lane will turn off autosearch in the background, even though combat has started correctly. This will cause ALAS to hang on the combat status screen since the code is actually expected AL to automatically skip this screen.

I've copied the status screen code from `combat.py` to address this in a quick and dirty way. Maybe someone who is more familiar with the code can clean it up and make everything more DRY though.

