### PR TITLE
Fix: New ship drop can result in game stuck exception during auto-search

### DIFF
--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -132,6 +132,9 @@ class AutoSearchCombat(Combat):
             else:
                 self.device.screenshot()
 
+            if self.handle_get_ship():
+                continue
+
             # End
             if self.is_auto_search_running():
                 break


### PR DESCRIPTION
As title states, after combat for auto-search new ships are displayed after battle, already obtained ships even for elite are not displayed seem to be the exception.