### PR TITLE
Fix: guild_logistics and handle_mystery for os_clear_map

### DIFF
--- a/module/guild/logistics.py
+++ b/module/guild/logistics.py
@@ -268,6 +268,7 @@ class GuildLogistics(GuildBase):
         logger.hr('Guild logistics')
         confirm_timer = Timer(1.5, count=3).start()
         exchange_interval = Timer(1.5, count=3)
+        click_interval = Timer(0.5, count=1)
         supply_checked = False
         mission_checked = False
         exchange_checked = False
@@ -298,14 +299,18 @@ class GuildLogistics(GuildBase):
             if self._is_in_guild_logistics():
                 # Supply
                 if not supply_checked and self._guild_logistics_supply_available():
-                    self.device.click(GUILD_SUPPLY)
+                    if click_interval.reached():
+                        self.device.click(GUILD_SUPPLY)
+                        click_interval.reset()
                     confirm_timer.reset()
                     continue
                 else:
                     supply_checked = True
                 # Mission
                 if not mission_checked and self._guild_logistics_mission_available():
-                    self.device.click(GUILD_MISSION)
+                    if click_interval.reached():
+                        self.device.click(GUILD_MISSION)
+                        click_interval.reset()
                     confirm_timer.reset()
                     continue
                 else:

--- a/module/os/fleet.py
+++ b/module/os/fleet.py
@@ -66,7 +66,8 @@ class OSFleet(OSCamera, Combat, Fleet, OSAsh):
         return sight
 
     def handle_mystery(self, button=None):
-        return False
+        # Treat map events as mystery, may walk into unexpected object on path
+        return self.handle_map_event()
 
     def handle_ambush(self):
         # Treat map events as ambush, to trigger walk retrying


### PR DESCRIPTION
- guild_logistics too many clicks due to poor timing screen capture is actually pretty frequent for my pc so kept as personal change unless another reported something similar. In use for weeks personally, no issue as far as I can tell.
- Recent change in camera.py considers mystery encounter on path, os_clear_map can run into something similar with unexpected object on path as well. So optimized to handle those situations.