### PR TITLE
Fix: fleet_switch_click() may fail when SWITCH_OVER not appeared

### DIFF
--- a/module/map/map_operation.py
+++ b/module/map/map_operation.py
@@ -24,9 +24,7 @@ class MapOperation(MysteryHandler, FleetPreparation, Retirement, FastForwardHand
         Switch fleet.
         """
         logger.info('Switch over')
-        if not self.appear(SWITCH_OVER):
-            logger.warning('No buttons detected.')
-            return False
+        self.wait_until_appear(SWITCH_OVER, skip_first_screenshot=True)
 
         FLEET_NUM.load_color(self.device.image)
         FLEET_NUM._match_init = True
@@ -37,7 +35,6 @@ class MapOperation(MysteryHandler, FleetPreparation, Retirement, FastForwardHand
             if not FLEET_NUM.match(self.device.image, offset=(0, 0), threshold=0.9):
                 break
             logger.warning('Fleet switch failed. Retrying.')
-        return True
 
     def enter_map(self, button, mode='normal'):
         """Enter a campaign.


### PR DESCRIPTION
If SWITCH_OVER not appeared (in most cases, connection unstable), we should wait for it instead of skipping the switch click.
Here the fleets were messed up.
```
2021-02-21 12:22:30.111 | INFO | Using function: battle_0
2021-02-21 12:22:30.111 | INFO | Fleet 2 step on
2021-02-21 12:22:30.115 | INFO | Fleet_2 step on A3
2021-02-21 12:22:30.115 | INFO | Switch over
2021-02-21 12:22:30.116 | WARNING | No buttons detected.
2021-02-21 12:22:31.153 | INFO |            tile_center: 0.955 (good match)
2021-02-21 12:22:31.169 | INFO | 0.081s  _   edge_lines: 3 hori, 2 vert
2021-02-21 12:22:31.169 | INFO | Edges: /_\   homo_loca: ( 25,  56)
2021-02-21 12:22:31.173 | INFO |            center_loca: (3, 2)
2021-02-21 12:22:31.173 | INFO |                 Camera: H1
```