### PR TITLE
Fix: sirens are not sea and cannot be passed through

### DIFF
--- a/module/map_detection/grid_info.py
+++ b/module/map_detection/grid_info.py
@@ -137,7 +137,7 @@ class GridInfo:
 
     @property
     def is_sea(self):
-        return False if self.is_land or self.is_enemy or self.is_boss else True
+        return False if self.is_land or self.is_enemy or self.is_siren or self.is_boss else True
 
     @property
     def may_carrier(self):


### PR DESCRIPTION
We use 'is_sea' to find path in find_path_initial(). Sirens cannot be passed through, so they should not be tagged 'is_sea'.
For example:
```
2021-03-28 04:33:08.729 | INFO |    A  B  C  D  E  F  G  H
2021-03-28 04:33:08.729 | INFO |  1 -- -- -- -- ++ ++ -- --
2021-03-28 04:33:08.729 | INFO |  2 -- 2M -- AR ++ ++ FL --
2021-03-28 04:33:08.729 | INFO |  3 ++ ++ ++ -- -- -- -- Fl
2021-03-28 04:33:08.729 | INFO |  4 -- -- -- -- -- -- -- --
2021-03-28 04:33:08.730 | INFO |  5 ++ ++ ++ -- ++ -- -- --
2021-03-28 04:33:08.730 | INFO |  6 -- -- -- -- 2C -- ++ --
2021-03-28 04:33:08.730 | INFO |  7 -- -- -- -- -- SA -- --
2021-03-28 04:33:08.734 | INFO |      A    B    C    D    E    F    G    H
2021-03-28 04:33:08.735 | INFO |  1    9    8    7    6 9999 9999    1    2
2021-03-28 04:33:08.735 | INFO |  2   10    7    6    5 9999 9999    0    1
2021-03-28 04:33:08.735 | INFO |  3 9999 9999 9999    4    3    2    1    2
2021-03-28 04:33:08.735 | INFO |  4    8    7    6    5    4    3    2    3
2021-03-28 04:33:08.735 | INFO |  5 9999 9999 9999    6 9999    4    3    4
2021-03-28 04:33:08.735 | INFO |  6   10    9    8    7    6    5 9999    5
2021-03-28 04:33:08.735 | INFO |  7   11   10    9    8    7    6    7    6
```
Here B2 is unreachable, but the cost is calculated to be 7 instead of 9999. This is a mistake, and may break the script in some conditions.