### PR TITLE
Fix: Handle potential map_event stuck

### DIFF
--- a/module/os_combat/combat.py
+++ b/module/os_combat/combat.py
@@ -159,6 +159,8 @@ class Combat(Combat_, MapEventHandler):
             # End
             if self.is_combat_executing():
                 continue
+            if handle_map_event():
+                continue
             if self.is_in_map():
                 self.device.screenshot_interval_set(0)
                 break

--- a/module/os_combat/combat.py
+++ b/module/os_combat/combat.py
@@ -159,7 +159,7 @@ class Combat(Combat_, MapEventHandler):
             # End
             if self.is_combat_executing():
                 continue
-            if handle_map_event():
+            if self.handle_map_event():
                 continue
             if self.is_in_map():
                 self.device.screenshot_interval_set(0)


### PR DESCRIPTION
Map event may appear too quickly before detection of exit thereby becoming stuck

For safety, keeping handle_map_event at its original timing place still may be needed so opted in not just relocating when it happens.

Pastebin log: https://pastebin.com/1FvZH5x2