### PR TITLE
Fix: handle popup of action_point_use

### DIFF
--- a/module/os_handler/action_point.py
+++ b/module/os_handler/action_point.py
@@ -56,6 +56,9 @@ class ActionPointHandler(UI):
                 self.device.sleep(0.3)
                 continue
 
+            if self.handle_popup_confirm():
+                continue
+
             self.action_point_update()
             if self._action_point_current > prev:
                 break


### PR DESCRIPTION
在重置前最后一天使用行动力箱子使得行动力超过200时会出现以下提示，需要识别处理。
![image](https://user-images.githubusercontent.com/57893649/116675378-5b9d5600-a9d8-11eb-9953-f9d04b53a8cd.png)
