### PR TITLE
Fix: correct items in dictionary.py

### DIFF
--- a/module/config/dictionary.py
+++ b/module/config/dictionary.py
@@ -47,7 +47,7 @@ dic_true_eng_to_eng = {
     'c12-4_leveling': 'c124_leveling',
     'os_semi_auto': 'os_semi_auto',
     'os_clear_map': 'os_clear_map',
-    'os_clear_world': 'os_clear_world',
+    'os_clear_world': 'os_world_clear',
     'os_fully_auto': 'os_fully_auto',
 
     # Argument
@@ -344,7 +344,7 @@ dic_chi_to_eng = {
     '12-4打大型练级': 'c124_leveling',
     '大世界辅助点击': 'os_semi_auto',
     '大世界地图全清': 'os_clear_map',
-    '大世界每月全清': 'os_clear_world',
+    '大世界每月全清': 'os_world_clear',
     '大世界全自动': 'os_fully_auto',
 
     # Argument
@@ -641,7 +641,7 @@ dic_tchi_to_eng = {
     '12-4打大型練級': 'c124_leveling',
     '大世界輔助點擊': 'os_semi_auto',
     '大世界地圖全清': 'os_clear_map',
-    '大世界每月全清': 'os_clear_world',
+    '大世界每月全清': 'os_world_clear',
     '大世界全自動': 'os_fully_auto',
 
     # Argument


### PR DESCRIPTION
启动大世界每月全清后报以下错误
```
Traceback (most recent call last):
  File "E:\games\AzurLaneScript\AzurLaneAutoScript\alas_jp_cn.pyw", line 8, in <module>
    main()
  File "E:\games\AzurLaneScript\AzurLaneAutoScript\toolkit\lib\site-packages\gooey\python_bindings\gooey_decorator.py", line 130, in <lambda>
    return lambda *args, **kwargs: func(*args, **kwargs)
  File "E:\games\AzurLaneScript\AzurLaneAutoScript\module\config\argparser.py", line 551, in main
    config[command][key] = str(value)
  File "E:\games\AzurLaneScript\AzurLaneAutoScript\toolkit\lib\configparser.py", line 958, in __getitem__
    raise KeyError(key)
KeyError: 'Os_clear_world'
```

在全部文件里只有`dictionary.py`能找这个词
里面出现`'os_clear_world': 'os_clear_world'`和`'大世界每月全清': 'os_clear_world'`
看了下ini文件里用的是`Os_world_clear`，怀疑是`dictionary.py`里的值写错了
尝试将`dictionary.py`里所有为`os_clear_world`的值改为`os_world_clear`后，成功运行