### PR TITLE
Fix: item number OCR wrong

### DIFF
--- a/module/os_handler/action_point.py
+++ b/module/os_handler/action_point.py
@@ -1,5 +1,6 @@
 from module.base.button import ButtonGrid
 from module.base.utils import *
+import module.config.server as server
 from module.logger import logger
 from module.ocr.ocr import Digit, DigitCounter
 from module.os_handler.assets import *
@@ -8,9 +9,14 @@ from module.ui.assets import OS_CHECK
 from module.ui.ui import UI
 
 OCR_ACTION_POINT_REMAIN = Digit(ACTION_POINT_REMAIN, letter=(255, 219, 66), name='OCR_ACTION_POINT_REMAIN')
-# Letters in ACTION_POINT_BUY_REMAIN are not the numeric fonts usually used in azur lane.
-OCR_ACTION_POINT_BUY_REMAIN = DigitCounter(
-    ACTION_POINT_BUY_REMAIN, letter=(148, 247, 99), lang='cnocr', name='OCR_ACTION_POINT_BUY_REMAIN')
+if server.server != 'jp':
+    # Letters in ACTION_POINT_BUY_REMAIN are not the numeric fonts usually used in azur lane.
+    OCR_ACTION_POINT_BUY_REMAIN = DigitCounter(
+        ACTION_POINT_BUY_REMAIN, letter=(148, 247, 99), lang='cnocr', name='OCR_ACTION_POINT_BUY_REMAIN')
+else:
+    # The color of the digits ACTION_POINT_BUY_REMAIN is white in JP, which is light green in CN and EN.
+    OCR_ACTION_POINT_BUY_REMAIN = DigitCounter(
+        ACTION_POINT_BUY_REMAIN, letter=(255, 255, 255), lang='cnocr', name='OCR_ACTION_POINT_BUY_REMAIN')
 ACTION_POINT_GRID = ButtonGrid(
     origin=(323, 274), delta=(173, 0), button_shape=(115, 115), grid_shape=(4, 1), name='ACTION_POINT_GRID')
 ACTION_POINT_ITEMS = ItemGrid(ACTION_POINT_GRID, templates={}, amount_area=(43, 89, 113, 113))

--- a/module/statistics/item.py
+++ b/module/statistics/item.py
@@ -20,7 +20,7 @@ class AmountOcr(Digit):
         return image.astype(np.uint8)
 
 
-AMOUNT_OCR = AmountOcr([], threshold=64, name='Amount_ocr')
+AMOUNT_OCR = AmountOcr([], threshold=96, name='Amount_ocr')
 PRICE_OCR = Digit([], letter=(255, 223, 57), threshold=128, name='Price_ocr')
 
 


### PR DESCRIPTION
![MuMu20210524015135](https://user-images.githubusercontent.com/16044351/119280393-3238b880-bc6c-11eb-8cfc-0f481a3b8031.png)
This screenshot was recognized as [358, 62, 0, 0].
Tuning the threshold from 64 to 96 solved the problem.
Here are the pre-processed images with thresholds 64, 96 and 128. I think 96 is a good balance.
![amount_64](https://user-images.githubusercontent.com/16044351/119280540-da4e8180-bc6c-11eb-8280-22173dd8864f.png)
![amount_96](https://user-images.githubusercontent.com/16044351/119280547-e4708000-bc6c-11eb-9ee3-7d8c247e5a30.png)
![amount_128](https://user-images.githubusercontent.com/16044351/119280549-e6d2da00-bc6c-11eb-97d9-7e87db65306e.png)
