### PR TITLE
Fix: [EN] HP check normal vs os map

### DIFF
--- a/module/combat/hp_balancer.py
+++ b/module/combat/hp_balancer.py
@@ -65,7 +65,7 @@ class HPBalancer(ModuleBase):
         )
         return data
 
-    @Config.when(SERVER='en')
+    @Config.when(SERVER='en', OS_RUNNING=False)
     def _hp_grid(self):
         # Location of six HP bar.
         return ButtonGrid(origin=(35, 190), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))

--- a/module/config/argparser_en.py
+++ b/module/config/argparser_en.py
@@ -584,7 +584,7 @@ def main(ini_name=''):
                                                   'purchase the OS logger item in main supply shop for '
                                                   '5k oil before using this module\n\n'
                                                   'Explore all unsafe zones between configured range inclusive and turn into safe\n'
-                                                  'Captains should configure approriately based on current adaptibility numbers '
+                                                  'Captains should configure appropriately based on current adaptibility numbers '
                                                   'and fleet formation',
                                                   gooey_options={'label_color': '#931D03'})
     os_world.add_argument('--os_world_min_level', default=default('--os_world_min_level'),

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -530,6 +530,7 @@ class AzurLaneConfig:
     ENABLE_OS_ACTION_POINT_BUY = False
     OS_ACTION_POINT_PRESERVE = 200
     OS_REPAIR_THRESHOLD = 0.4
+    OS_RUNNING = False
     OS_ACTION_POINT_BOX_USE = True
     # 1 to 6. Recommend 3 or 5 for higher meowfficer searching point per action points ratio.
     OS_MEOWFFICER_FARMING_LEVEL = 5

--- a/module/os/fleet.py
+++ b/module/os/fleet.py
@@ -114,7 +114,7 @@ class OSFleet(OSCamera, Combat, Fleet, OSAsh):
         else:
             return ''
 
-    @Config.when(SERVER='en')
+    @Config.when(SERVER='en', OS_RUNNING=True)
     def _hp_grid(self):
         # Location of six HP bar.
         return ButtonGrid(origin=(35, 205), delta=(0, 100), button_shape=(66, 3), grid_shape=(1, 6))

--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -238,8 +238,8 @@ class OperationSiren(OSMap):
         Returns:
             bool: If executed.
         """
-        # Force to use AP boxes
-        backup = self.config.cover(OS_ACTION_POINT_PRESERVE=40, OS_ACTION_POINT_BOX_USE=True)
+        # Force to use AP boxes and switch to use _hp_grid from os/fleet.py rather than combat/hp_balancer.py
+        backup = self.config.cover(OS_ACTION_POINT_PRESERVE=40, OS_ACTION_POINT_BOX_USE=True, OS_RUNNING=True)
 
         # Fleet repairs before starting if needed
         self.handle_fleet_repair(revert=False)
@@ -287,18 +287,23 @@ class OperationSiren(OSMap):
             self.os_meowfficer_farming(hazard_level=self.config.OS_MEOWFFICER_FARMING_LEVEL, daily=daily)
 
     def operation_siren(self):
+        # Switch to use _hp_grid from os/fleet.py rather than combat/hp_balancer.py
+        backup = self.config.cover(OS_RUNNING=True)
+
         try:
             self._operation_siren(daily=False)
         except ActionPointLimit:
             pass
+
+        backup.recover()
 
     def operation_siren_daily(self):
         """
         Returns:
             bool: If executed.
         """
-        # Force to use AP boxes
-        backup = self.config.cover(OS_ACTION_POINT_PRESERVE=40)
+        # Force to use AP boxes and switch to use _hp_grid from os/fleet.py rather than combat/hp_balancer.py
+        backup = self.config.cover(OS_ACTION_POINT_PRESERVE=40, OS_RUNNING=True)
 
         try:
             self._operation_siren(daily=True)


### PR DESCRIPTION
I have been using this arrangement for a few days and can verify calls the correct `_hp_grid`

Just saw your discord suggestion in using the old way though.

To clarify, you are suggesting to consolidate `_hp_grid` back to one declaration and not  use `@Config`?
```
def _hp_grid(self):
    if server.server == 'en':
        return 'EN ButtonGrid'
    elif server.server == 'jp':
        return 'JP ButtonGrid'
    else:
        return 'CN ButtonGrid'
```
I think I see your point with the two instances independent without using `@Config` then it should appropriately use the correct _hp_grid since a function pointer/address isn't used anymore. Perhaps in os/fleet.py then...
 ```
def _hp_grid(self):
    btnGrid = super()._hp_grid()
    if server.server == 'en':
        btnGrid.origin = ...
        ...
    elif server.server == 'jp':
        pass
    else:
        pass
    return btnGrid
```
This way no internal config or switch is needed to differentiate.