### PR TITLE
Fix: [EN] HP check in normal vs os

### DIFF
--- a/module/combat/hp_balancer.py
+++ b/module/combat/hp_balancer.py
@@ -65,20 +65,14 @@ class HPBalancer(ModuleBase):
         )
         return data
 
-    @Config.when(SERVER='en')
     def _hp_grid(self):
-        # Location of six HP bar.
-        return ButtonGrid(origin=(35, 190), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))
-
-    @Config.when(SERVER='jp')
-    def _hp_grid(self):
-        # Location of six HP bar.
-        return ButtonGrid(origin=(35, 205), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))
-
-    @Config.when(SERVER=None)
-    def _hp_grid(self):
-        # Location of six HP bar.
-        return ButtonGrid(origin=(35, 206), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))
+        # Location of six HP bar, according to respective server for campaign
+        if self.config.SERVER == 'en':
+            return ButtonGrid(origin=(35, 190), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))
+        elif self.config.SERVER == 'jp':
+            return ButtonGrid(origin=(35, 205), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))
+        else:
+            return ButtonGrid(origin=(35, 206), delta=(0, 100), button_shape=(66, 4), grid_shape=(1, 6))
 
     def hp_get(self):
         """Get current HP from screenshot.

--- a/module/config/argparser_en.py
+++ b/module/config/argparser_en.py
@@ -584,7 +584,7 @@ def main(ini_name=''):
                                                   'purchase the OS logger item in main supply shop for '
                                                   '5k oil before using this module\n\n'
                                                   'Explore all unsafe zones between configured range inclusive and turn into safe\n'
-                                                  'Captains should configure approriately based on current adaptibility numbers '
+                                                  'Captains should configure appropriately based on current adaptibility numbers '
                                                   'and fleet formation',
                                                   gooey_options={'label_color': '#931D03'})
     os_world.add_argument('--os_world_min_level', default=default('--os_world_min_level'),

--- a/module/os/fleet.py
+++ b/module/os/fleet.py
@@ -114,10 +114,18 @@ class OSFleet(OSCamera, Combat, Fleet, OSAsh):
         else:
             return ''
 
-    @Config.when(SERVER='en')
     def _hp_grid(self):
-        # Location of six HP bar.
-        return ButtonGrid(origin=(35, 205), delta=(0, 100), button_shape=(66, 3), grid_shape=(1, 6))
+        hp_grid = super()._hp_grid()
+
+        # Location of six HP bar, according to respective server for os
+        if self.config.SERVER == 'en':
+            hp_grid = ButtonGrid(origin=(35, 205), delta=(0, 100), button_shape=(66, 3), grid_shape=(1, 6))
+        elif self.config.SERVER == 'jp':
+            pass
+        else:
+            pass
+
+        return hp_grid
 
     def hp_withdraw_triggered(self):
         return False


### PR DESCRIPTION
- Deprecate `@Config` use for `_hp_grid` to allow differentiated use depending on running module.  Otherwise, only the last defined is used.
- Spell check in argparser_en