### PR TITLE
Fix: 2x book detect in auto search continue/exit

### DIFF
--- a/module/handler/fast_forward.py
+++ b/module/handler/fast_forward.py
@@ -16,7 +16,7 @@ auto_search.add_status('off', check_button=AUTO_SEARCH_OFF)
 book_prep = Switch('2x Book Prep', offset=(20, 20))
 book_prep.add_status('on', check_button=BOOK_ON_PREP)
 book_prep.add_status('off', check_button=BOOK_OFF_PREP)
-book_auto = Switch('2x Book Auto', offset=(20, 20))
+book_auto = Switch('2x Book Auto')
 book_auto.add_status('on', check_button=BOOK_ON_AUTO)
 book_auto.add_status('off', check_button=BOOK_OFF_AUTO)
 

--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -126,11 +126,11 @@ class OperationSiren(OSMap):
                            f'{str(int(self.config.OS_REPAIR_THRESHOLD * 100))}%, '
                             'retreating to nearest azur port for repairs')
                 self.fleet_repair(revert=revert)
-                self.hp_reset()
             else:
                 logger.info('No ship found to be below threshold '
                            f'{str(int(self.config.OS_REPAIR_THRESHOLD * 100))}%, '
                             'continue OS exploration')
+            self.hp_reset()
 
     def os_port_daily(self, mission=True, supply=True):
         """


### PR DESCRIPTION
- Removing the offset allows consistent detection of box on different maps. For some reason, campaigns with blue vs red (chapter vs event) background contributes to the color of the box so offset works exclusively for one but not the other. Though it seems box detection when in fleet preparation has no issue with offset being specified regardless of map.
- I wouldn't say the hp_reset move is a fix but it was something I had forgotten to do in the initial PR since it should reset after either case whether their fleet went to port or not.

Didn't want to commit this since it is a hack but I do often get `PINNED_DISABLE` too many tries exception. But maybe something to consider since a degree of randomness does factor in encountering this and I don't think disturbs too much as the too long exception can still potentially occur which would be understandable.  Otherwise I'll just keep it for myself since it likely results from poor pc or lag of emulator.
```
if self.is_zone_pinned():
    # A click does not disable pinned zone, a swipe does.
    self.device.swipe((50, -50), box=area_pad(ZONE_PINNED.area, pad=-80), random_range=(-10, -10, 10, 10),
                      padding=0, name='PINNED_DISABLE')
    self.device.click_record.pop() # this line being the hack, basically preventing the too many clicks for this action only
```

Also, port traversals don't use any reference maps like an actual campaign so depending on where the fleets enter from, some grids have islands/blocker tiles which ALAS sometimes calculate as part of the route however being unable to move, it keeps trying and run into the too many click. Hasn't happened recently so no log output but if it does come about, I'll share it.