### PR TITLE
Fix: handle incompletable OS daily coin mission

### DIFF
--- a/module/os_handler/mission.py
+++ b/module/os_handler/mission.py
@@ -149,13 +149,23 @@ class MissionHandler(GlobeOperation, ZoneManager):
 
         logger.info('Checkout os mission')
         skip_first_screenshot = True
+
+        # Count mission_checkout click times
+        # If too many, means only coin missions left
+        mission_checkout_count = 0
+
         while 1:
+            if mission_checkout_count >= 10:
+                logger.info('Only incompletable coin missions left')
+                return False
+
             if skip_first_screenshot:
                 skip_first_screenshot = False
             else:
                 self.device.screenshot()
 
             if self.appear_then_click(MISSION_CHECKOUT, offset=(20, 20), interval=2):
+                mission_checkout_count = mission_checkout_count +1
                 continue
             if self.is_zone_pinned():
                 logger.info('Pinned at mission zone')

--- a/module/os_handler/mission.py
+++ b/module/os_handler/mission.py
@@ -156,7 +156,8 @@ class MissionHandler(GlobeOperation, ZoneManager):
 
         while 1:
             if mission_checkout_count >= 10:
-                logger.info('Only incompletable coin missions left')
+                logger.info('Only incompletable OS coin missions left')
+                self.os_mission_quit()
                 return False
 
             if skip_first_screenshot:


### PR DESCRIPTION
#489 
当存在无法完成的大世界兑换任务时，游戏会将其自动排在任务列表最下面
因此当连续点击10次（比弹出Too many click少2次）前往地图无反应时，认为只剩下无法完成的兑换任务（不考虑网络错误和性能不足而卡顿的情况），结束大世界每日任务并记为完成

logs表现如下
```
2021-06-18 14:13:56.078 | INFO | <<< OS INIT >>>
2021-06-18 14:13:56.929 | INFO | [Screen_size] 1280x720
2021-06-18 14:13:56.941 | INFO | Already in os map
2021-06-18 14:13:56.963 | INFO | Loading OCR model: ./bin/cnocr_models/jp
2021-06-18 14:13:57.107 | INFO | [MAP_NAME 0.164s] リバ一プール
2021-06-18 14:13:57.107 | INFO | Map name processed: リバープール
2021-06-18 14:13:57.108 | INFO | [Zone] [1|利维浦|Liverpool|リバープール]
2021-06-18 14:13:57.109 | INFO | Ash beacon fully collected today
2021-06-18 14:13:57.109 | INFO | -------------------- OS AUTO SEARCH --------------------
2021-06-18 14:13:57.925 | INFO | Click (1232,  583) @ AUTO_SEARCH_OS_MAP_OPTION_OFF
2021-06-18 14:13:59.718 | INFO | Get OS auto search reward
2021-06-18 14:14:00.506 | INFO | OS auto search finished
2021-06-18 14:14:00.506 | INFO | Current zone is a port, do not have akashi
2021-06-18 14:14:00.506 | INFO | [DailyRecord_os_mission_accept] Record time: 2021-06-17 23:58:14
2021-06-18 14:14:00.506 | INFO | [DailyRecord_os_mission_accept] Last update: 2021-06-17 23:00:00
2021-06-18 14:14:00.506 | INFO | [DailyRecord_os_supply_buy] Record time: 2021-06-17 23:58:14
2021-06-18 14:14:00.507 | INFO | [DailyRecord_os_supply_buy] Last update: 2021-06-17 23:00:00
2021-06-18 14:14:00.510 | INFO | [HP]  75%  80%  98%  80%  57%  40%
2021-06-18 14:14:00.510 | INFO | No ship found to be below threshold 15%, continue OS exploration
2021-06-18 14:14:00.510 | INFO | [DailyRecord_os_mission_finish] Record time: 2021-06-17 14:11:35
2021-06-18 14:14:00.510 | INFO | [DailyRecord_os_mission_finish] Last update: 2021-06-17 23:00:00
2021-06-18 14:14:00.510 | INFO | ==================== OS FINISH DAILY MISSION ====================
2021-06-18 14:14:00.510 | INFO | OS mission enter
2021-06-18 14:14:00.522 | INFO | Click ( 799,  672) @ MISSION_ENTER
2021-06-18 14:14:02.952 | INFO | Checkout os mission
2021-06-18 14:14:02.952 | INFO | Click (1041,  220) @ MISSION_CHECKOUT
2021-06-18 14:14:05.310 | INFO | Click (1069,  227) @ MISSION_CHECKOUT
2021-06-18 14:14:07.674 | INFO | Click (1087,  224) @ MISSION_CHECKOUT
2021-06-18 14:14:10.065 | INFO | Click (1080,  216) @ MISSION_CHECKOUT
2021-06-18 14:14:12.543 | INFO | Click (1056,  225) @ MISSION_CHECKOUT
2021-06-18 14:14:14.815 | INFO | Click (1072,  227) @ MISSION_CHECKOUT
2021-06-18 14:14:17.297 | INFO | Click (1087,  221) @ MISSION_CHECKOUT
2021-06-18 14:14:19.614 | INFO | Click (1055,  218) @ MISSION_CHECKOUT
2021-06-18 14:14:22.060 | INFO | Click (1078,  215) @ MISSION_CHECKOUT
2021-06-18 14:14:24.207 | INFO | Click (1052,  221) @ MISSION_CHECKOUT
2021-06-18 14:14:24.317 | INFO | Only incompletable OS coin missions left
2021-06-18 14:14:24.317 | INFO | OS mission quit
2021-06-18 14:14:24.317 | INFO | <<< UI CLICK >>>
2021-06-18 14:14:24.424 | INFO | Click (1112,  121) @ MISSION_QUIT
2021-06-18 14:14:26.063 | INFO | [Daily_executed] 0/6
2021-06-18 14:14:26.064 | INFO | <<< REWARD LOOP >>>
2021-06-18 14:14:26.064 | INFO | <<< REWARD START >>>
```