### PR TITLE
Fix: interval_reset for AUTO_SEARCH_MENU_CONTINUE

### DIFF
--- a/module/handler/fast_forward.py
+++ b/module/handler/fast_forward.py
@@ -149,6 +149,7 @@ class FastForwardHandler(AutoSearchHandler):
             self.map_is_2x_book = self.config.ENABLE_2X_BOOK
             self.handle_2x_book_setting(mode='auto')
             self.device.click(AUTO_SEARCH_MENU_CONTINUE)
+            self.interval_reset(AUTO_SEARCH_MENU_CONTINUE)
             return True
         return False
 


### PR DESCRIPTION
Can throw off timing and re-enter `handle_2x_book_setting` due to immediate detection of residual button displayed after click as its current `interval=2` lapse can long pass within `handle_2x_book_setting`.