### PR TITLE
Add: confirm_wait optional parameter for ui_ensure/ui_goto (tentative)

### DIFF
--- a/module/reward/dorm.py
+++ b/module/reward/dorm.py
@@ -227,7 +227,7 @@ class RewardDorm(UI):
             if not feed:
                 self.ui_goto_main()
                 return
-        self.ui_goto(page_dorm, skip_first_screenshot=True)
+        self.ui_goto(page_dorm, confirm_wait=3, skip_first_screenshot=True)
 
         if collect:
             self._dorm_receive()

--- a/module/reward/meowfficer.py
+++ b/module/reward/meowfficer.py
@@ -264,7 +264,7 @@ class RewardMeowfficer(UI):
         if not buy and not train:
             return False
 
-        self.ui_ensure(page_meowfficer)
+        self.ui_ensure(page_meowfficer, confirm_wait=3)
 
         if buy:
             self.meow_buy()

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -111,10 +111,13 @@ class UI(InfoHandler):
             else:
                 exit(1)
 
-    def ui_goto(self, destination, skip_first_screenshot=False):
+    def ui_goto(self, destination, confirm_wait=1, skip_first_screenshot=False):
         """
         Args:
             destination (Page):
+            confirm_wait (int, float):
+                for pages with additional
+                which need longer confirmation
             skip_first_screenshot (bool):
         """
         for page in self.ui_pages_all:
@@ -161,6 +164,7 @@ class UI(InfoHandler):
                 click_button=p1.links[p2],
                 check_button=p2.check_button,
                 additional=self.__getattribute__(additional) if hasattr(self, additional) else None,
+                confirm_wait=confirm_wait,
                 offset=(20, 20),
                 skip_first_screenshot=skip_first_screenshot)
             self.ui_current = p2
@@ -170,10 +174,13 @@ class UI(InfoHandler):
         for page in visited:
             page.parent = None
 
-    def ui_ensure(self, destination):
+    def ui_ensure(self, destination, confirm_wait=1):
         """
         Args:
             destination (Page):
+            confirm_wait (int, float):
+                for pages with additional
+                which need longer confirmation
         """
         logger.hr('UI ensure')
         self.ui_get_current_page()
@@ -182,7 +189,7 @@ class UI(InfoHandler):
             return False
         else:
             logger.info('Goto %s' % destination)
-            self.ui_goto(destination)
+            self.ui_goto(destination, confirm_wait=confirm_wait)
             return True
 
     def ui_goto_main(self):


### PR DESCRIPTION
The main topic is `page_meowfficer` or `page_dorm` still often lags behind on `*_INFO` pop ups. The `*_CHECK` assets seem to load first and with having `confirm_wait=1` by default I think is where the problem might be since those `*_INFO` tend to appear `> 1`.

Sure, it adds more delay now but now it has better chance encountering those `ui_additional_*` funcs. I had wondered why `_dorm_receive` had special circumstances when really those funcs should be handlng it.

The only scenario that uses `confirm_wait > 1` is for withdrawing from a campaign, so since there is case to use it. Extending the usage to these pages I think is reasonable.

But if you think this just impedes ALAS too much, I understand.
