### PR TITLE
Fix: use raid_daily_name (not raid_name) in Daily

### DIFF
--- a/module/raid/daily.py
+++ b/module/raid/daily.py
@@ -16,7 +16,7 @@ class RaidDaily(RaidRun):
         Returns:
             int:
         """
-        ocr = raid_ocr(raid=self.config.RAID_NAME, mode=mode)
+        ocr = raid_ocr(raid=self.config.RAID_DAILY_NAME, mode=mode)
         remain, _, _ = ocr.ocr(self.device.image)
         logger.attr(f'{mode.capitalize()} Remain', remain)
         return remain
@@ -33,7 +33,7 @@ class RaidDaily(RaidRun):
             name (str): Raid name, such as 'raid_20200624'
         """
         self.reward_backup_daily_reward_settings()
-        name = name if name else self.config.RAID_NAME
+        name = name if name else self.config.RAID_DAILY_NAME
         self.ui_ensure(page_raid)
 
         if self.config.RAID_HARD:

--- a/module/raid/raid.py
+++ b/module/raid/raid.py
@@ -138,9 +138,9 @@ class Raid(MapOperation, Combat):
 
         return False
 
-    def raid_enter(self, mode):
+    def raid_enter(self, mode, raid):
         logger.hr('Raid Enter')
-        entrance = raid_entrance(raid=self.config.RAID_NAME, mode=mode)
+        entrance = raid_entrance(raid=raid, mode=mode)
         while 1:
             self.device.screenshot()
 
@@ -156,8 +156,8 @@ class Raid(MapOperation, Combat):
     def raid_expected_end(self):
         return self.appear(RAID_CHECK, offset=(30, 30))
 
-    def raid_execute_once(self, mode):
+    def raid_execute_once(self, mode, raid):
         logger.hr('Raid Execute')
-        self.raid_enter(mode=mode)
+        self.raid_enter(mode=mode, raid=raid)
         self.combat(balance_hp=False, expected_end=self.raid_expected_end)
         logger.hr('Raid End')

--- a/module/raid/run.py
+++ b/module/raid/run.py
@@ -50,7 +50,7 @@ class RaidRun(Raid, CampaignRun):
 
             # Run
             try:
-                self.raid_execute_once(mode=mode if mode else self.config.RAID_MODE)
+                self.raid_execute_once(mode=mode if mode else self.config.RAID_MODE, raid=name)
             except OilExhausted:
                 self.ui_goto_main()
                 break


### PR DESCRIPTION
#532 #522 
共斗和每日共斗使用同一个设置项可能会使config维护较为麻烦
因此修改raid相关代码使其能够正确读取使用 raid_daily_name