### PR TITLE
跳过尝试连接emulator

### DIFF
--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -80,14 +80,17 @@ class Connection:
         self.adb_command(cmd, serial)
 
     def _adb_connect(self, serial):
-        for _ in range(3):
-            msg = self.adb_command(['connect', serial]).decode("utf-8").strip()
-            logger.info(msg)
-            if 'already' in msg:
-                return True
-
-        logger.warning(f'Failed to connect {serial} after 3 trial.')
-        return False
+        if 'emulator' in serial:
+            return True
+        else:
+            for _ in range(3):
+                msg = self.adb_command(['connect', serial]).decode("utf-8").strip()
+                logger.info(msg)
+                if 'already' in msg:
+                    return True
+                else:
+                    logger.warning(f'Failed to connect {serial} after 3 trial.')
+                    return False
 
     def connect(self, serial):
         """Connect to a device.


### PR DESCRIPTION
adb connect连的是ip+端口，应该连不上emulator-55xx吧（
这里我猜测用途是用于连接端口不在5555-5585之间的模拟器，也就是说是ip+端口形式，所以稍微改了下判断，让脚本检测到serial中包含"emulator"的时候跳过这个步骤（
第一次提pr，有啥问题请见谅（
~~主要是每次开脚本都硬拖我10几秒很不开心，就去看了2分钟python教程改掉了~~