### PR TITLE
卡白屏不知道是不是跳了connect这一步的原因，加个连接时的adb devices的输出看看（

### DIFF
--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -81,7 +81,15 @@ class Connection:
 
     def _adb_connect(self, serial):
         if 'emulator' in serial:
-            return True
+            emulinkstats = self.adb_command(['devices']).decode("utf-8").strip().replace('List of devices attached', '')
+            if 'device' in emulinkstats:
+                logger.info('Connected emulator detected')
+                logger.info('devices state: ' + emulinkstats.replace('\n', '').replace('\r', ''))
+                return True
+            else:
+                logger.warning('No connected emulator detected')
+                logger.info('devices state' + emulinkstats.replace('\n', '').replace('\r', ''))
+                return False
         else:
             for _ in range(3):
                 msg = self.adb_command(['connect', serial]).decode("utf-8").strip()


### PR DESCRIPTION
~~方便甩锅（bushi~~
逻辑是检测到serial里有emulator不是直接跳过，而再输出一下现在的设备列表（
如果没得device说明我上次改的害了人让有的人卡启动了**呜呜呜**
![呜呜呜](https://user-images.githubusercontent.com/40208202/130825690-401f842d-5cf6-4c17-86f9-8aad4b0294b8.gif)
