### PR TITLE
Fix: handle GET_ITMES popup when goto page_os

### DIFF
--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 
+from module.combat.assets import GET_ITEMS_1, GET_ITEMS_2, GET_ITEMS_3
 from module.exception import MapWalkError
 from module.exception import ScriptError
 from module.logger import logger
@@ -47,7 +48,19 @@ class OperationSiren(Reward, OSMap):
             self.device.screenshot()
 
         # Init
-        self.get_current_zone()
+        _get_current_zone_success = False
+        for _ in range(5):
+            try:
+                self.get_current_zone()
+                _get_current_zone_success = True
+                break
+            except:
+                self.handle_map_event()
+            finally:
+                self.device.screenshot()
+        if not _get_current_zone_success:
+            self.get_current_zone()
+
         # self.map_init()
         self.hp_reset()
 


### PR DESCRIPTION
打大世界掉道具的敌人没结算完就退出游戏，重进大世界会弹出 get_items

![2021-10-16_22-26-07-561186](https://user-images.githubusercontent.com/57893649/137593802-5ba7078d-8a13-4833-b6df-53d0bc032ceb.png)
![2021-10-16_22-26-08-240699](https://user-images.githubusercontent.com/57893649/137593805-c44e81b7-50ef-48c9-b56c-4ea2c632a7a0.png)
![2021-10-16_22-26-09-018336](https://user-images.githubusercontent.com/57893649/137593807-5c2e008f-7405-46d1-882c-9d5962ef5273.png)

```
2021-10-16 22:25:47.837 | INFO | <<< OS INIT >>>
2021-10-16 22:25:49.110 | INFO | [Screen_size] 1280x720
2021-10-16 22:25:49.208 | INFO | <<< UI ENSURE >>>
2021-10-16 22:25:50.027 | INFO | [UI] page_main
2021-10-16 22:25:50.027 | INFO | Goto page_os
2021-10-16 22:25:50.027 | INFO | [UI route] page_main - page_campaign_menu - page_os
2021-10-16 22:25:50.028 | INFO | <<< UI CLICK >>>
2021-10-16 22:25:50.895 | INFO | Click (1089,  334) @ MAIN_GOTO_CAMPAIGN
2021-10-16 22:26:02.971 | INFO | <<< UI CLICK >>>
2021-10-16 22:26:02.987 | INFO | Click ( 754,  493) @ CAMPAIGN_MENU_GOTO_OS
2021-10-16 22:26:09.192 | WARNING | Trying to get zone name, but not in OS map
2021-10-16 22:26:09.193 | ERROR | Trying to get zone name, but not in OS map
Traceback (most recent call last):
  File "C:\fakepath\AzurLaneAutoScript\alas.py", line 29, in run
    self.__getattribute__(command.lower())()
  File "C:\fakepath\AzurLaneAutoScript\alas.py", line 251, in os_world_clear
    az.run_clear_os_world()
  File "C:\fakepath\AzurLaneAutoScript\module\campaign\os_run.py", line 52, in run_clear_os_world
    self.load_campaign()
  File "C:\fakepath\AzurLaneAutoScript\module\campaign\os_run.py", line 21, in load_campaign
    self.campaign.os_init()
  File "C:\fakepath\AzurLaneAutoScript\module\os\operation_siren.py", line 55, in os_init
    self.get_current_zone()
  File "C:\fakepath\AzurLaneAutoScript\module\os\map_operation.py", line 85, in get_current_zone
    raise ScriptError('Trying to get zone name, but not in OS map')
module.exception.ScriptError: Trying to get zone name, but not in OS map
2021-10-16 22:26:09.195 | INFO | Saving error: ./log/error/1634394369195
```