### PR TITLE
Fix: handle shop items loading not finished

### DIFF
--- a/module/shop/base.py
+++ b/module/shop/base.py
@@ -80,6 +80,28 @@ class ShopBase(UI):
         except AttributeError:
             logger.warning(f'shop_get_currency --> Missing func shop_{key}_get_currency')
 
+    def shop_items_loading_finished(self, items, key='medal'):
+        """
+        Check if shop items loading is finished. If not, the game shows some default items.
+
+        Args:
+            items: list[Item]
+            key: String identifies which shop
+
+        Returns:
+            bool:
+        """
+        # Use default price to check
+        try:
+            default_price = self.__getattribute__(f'shop_{key}_default_price')
+        except AttributeError:
+            return True
+
+        for item in items:
+            if int(item.price) == default_price:
+                return False
+        return True
+
     def shop_get_items(self, key='general'):
         """
         Args:
@@ -95,14 +117,20 @@ class ShopBase(UI):
             logger.warning(f'shop_get_items --> Missing cached_property shop_{key}_items')
             return []
 
-        item_grid.predict(
-            self.device.image,
-            name=True,
-            amount=False,
-            cost=True if key == 'general' else False,
-            price=True,
-            tag=False
-        )
+        while 1:
+            item_grid.predict(
+                self.device.image,
+                name=True,
+                amount=False,
+                cost=True if key == 'general' else False,
+                price=True,
+                tag=False
+            )
+
+            if self.shop_items_loading_finished(item_grid.items):
+                break
+
+            self.device.screenshot()
 
         items = item_grid.items
         if len(items):

--- a/module/shop/shop_medal.py
+++ b/module/shop/shop_medal.py
@@ -62,6 +62,16 @@ class MedalShop(ShopBase):
         shop_medal_items.similarity = 0.88  # Lower the threshold for consistent matches of PR/DRBP
         return shop_medal_items
 
+    @cached_property
+    def shop_medal_default_price(self):
+        """
+        return default price shows when shop items loading is not finished
+
+        Returns:
+            int
+        """
+        return 5000
+
     def shop_medal_check_item(self, item):
         """
         Args:


### PR DESCRIPTION
#659
确实是因为重启游戏后，进入商店界面，物品加载出来前显示了默认价格

暂时只发现了 medal shop 有这种情况，其它 shop 先留空
不清楚不同服务器默认显示是否相同