### PR TITLE
Fix: Split shop task

### DIFF
--- a/alas.py
+++ b/alas.py
@@ -135,9 +135,13 @@ class AzurLaneAutoScript:
         from module.reward.reward import Reward
         Reward(config=self.config, device=self.device).run()
 
-    def shop(self):
+    def shop_frequent(self):
         from module.shop.shop_reward import RewardShop
-        RewardShop(config=self.config, device=self.device).run()
+        RewardShop(config=self.config, device=self.device).run_frequent()
+
+    def shop_once(self):
+        from module.shop.shop_reward import RewardShop
+        RewardShop(config=self.config, device=self.device).run_once()
 
     def shipyard(self):
         from module.shipyard.shipyard_reward import RewardShipyard

--- a/config/template.json
+++ b/config/template.json
@@ -677,11 +677,11 @@
       "CollectMission": true
     }
   },
-  "Shop": {
+  "ShopFrequent": {
     "Scheduler": {
       "Enable": false,
       "NextRun": "2020-01-01 00:00:00",
-      "Command": "Shop",
+      "Command": "ShopFrequent",
       "SuccessInterval": 30,
       "FailureInterval": 30,
       "ServerUpdate": "00:00, 12:00, 18:00"
@@ -690,6 +690,16 @@
       "UseGems": false,
       "Refresh": false,
       "Filter": "BookRedT3 > BookYellowT3 > BookBlueT3 > BookRedT2\n> Cube\n> FoodT6 > FoodT5"
+    }
+  },
+  "ShopOnce": {
+    "Scheduler": {
+      "Enable": false,
+      "NextRun": "2020-01-01 00:00:00",
+      "Command": "ShopOnce",
+      "SuccessInterval": 30,
+      "FailureInterval": 30,
+      "ServerUpdate": "00:00"
     },
     "GuildShop": {
       "Refresh": true,

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -3079,7 +3079,7 @@
       }
     }
   },
-  "Shop": {
+  "ShopFrequent": {
     "Scheduler": {
       "Enable": {
         "type": "checkbox",
@@ -3091,7 +3091,7 @@
       },
       "Command": {
         "type": "disable",
-        "value": "Shop"
+        "value": "ShopFrequent"
       },
       "SuccessInterval": {
         "type": "disable",
@@ -3118,6 +3118,34 @@
       "Filter": {
         "type": "textarea",
         "value": "BookRedT3 > BookYellowT3 > BookBlueT3 > BookRedT2\n> Cube\n> FoodT6 > FoodT5"
+      }
+    }
+  },
+  "ShopOnce": {
+    "Scheduler": {
+      "Enable": {
+        "type": "checkbox",
+        "value": false
+      },
+      "NextRun": {
+        "type": "input",
+        "value": "2020-01-01 00:00:00"
+      },
+      "Command": {
+        "type": "disable",
+        "value": "ShopOnce"
+      },
+      "SuccessInterval": {
+        "type": "disable",
+        "value": 30
+      },
+      "FailureInterval": {
+        "type": "disable",
+        "value": 30
+      },
+      "ServerUpdate": {
+        "type": "disable",
+        "value": "00:00"
       }
     },
     "GuildShop": {

--- a/module/config/argument/menu.json
+++ b/module/config/argument/menu.json
@@ -23,7 +23,8 @@
       "Meowfficer",
       "Guild",
       "Reward",
-      "Shop",
+      "ShopFrequent",
+      "ShopOnce",
       "Shipyard",
       "Gacha",
       "DataKey"

--- a/module/config/argument/override.yaml
+++ b/module/config/argument/override.yaml
@@ -150,11 +150,16 @@ Reward:
     SuccessInterval: 60-120
     FailureInterval: 60-120
     ServerUpdate: 00:00
-Shop:
+ShopFrequent:
   Scheduler:
     SuccessInterval: 30
     FailureInterval: 30
     ServerUpdate: 00:00, 12:00, 18:00
+ShopOnce:
+  Scheduler:
+    SuccessInterval: 30
+    FailureInterval: 30
+    ServerUpdate: 00:00
 Shipyard:
   Scheduler:
     SuccessInterval: 30

--- a/module/config/argument/task.yaml
+++ b/module/config/argument/task.yaml
@@ -104,9 +104,11 @@ Guild:
 Reward:
   - Scheduler
   - Reward
-Shop:
+ShopFrequent:
   - Scheduler
   - GeneralShop
+ShopOnce:
+  - Scheduler
   - GuildShop
   - MedalShop
   - MeritShop

--- a/module/config/config_manual.py
+++ b/module/config/config_manual.py
@@ -7,7 +7,7 @@ class ManualConfig:
     SCHEDULER_PRIORITY = """
     Restart
     > Research > Commission > Tactical > Dorm > Meowfficer > Guild > Reward
-    > Gacha > Shop > Shipyard > DataKey
+    > Gacha > ShopFrequent > ShopOnce > Shipyard > DataKey
     > OpsiExplore > OpsiObscure
     > Exercise > Daily > Hard > OpsiAshAssist
     > Sos > EventSp > EventAb > RaidDaily > WarArchives

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -102,8 +102,12 @@
       "name": "Reward",
       "help": ""
     },
-    "Shop": {
-      "name": "Shop",
+    "ShopFrequent": {
+      "name": "ShopFrequent",
+      "help": ""
+    },
+    "ShopOnce": {
+      "name": "ShopOnce",
       "help": ""
     },
     "Shipyard": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -102,9 +102,13 @@
       "name": "Task.Reward.name",
       "help": "Task.Reward.help"
     },
-    "Shop": {
-      "name": "Task.Shop.name",
-      "help": "Task.Shop.help"
+    "ShopFrequent": {
+      "name": "Task.ShopFrequent.name",
+      "help": "Task.ShopFrequent.help"
+    },
+    "ShopOnce": {
+      "name": "Task.ShopOnce.name",
+      "help": "Task.ShopOnce.help"
     },
     "Shipyard": {
       "name": "Task.Shipyard.name",

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -102,8 +102,12 @@
       "name": "收获",
       "help": ""
     },
-    "Shop": {
+    "ShopFrequent": {
       "name": "商店购买",
+      "help": ""
+    },
+    "ShopOnce": {
+      "name": "Task.ShopOnce.name",
       "help": ""
     },
     "Shipyard": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -102,9 +102,13 @@
       "name": "Task.Reward.name",
       "help": "Task.Reward.help"
     },
-    "Shop": {
-      "name": "Task.Shop.name",
-      "help": "Task.Shop.help"
+    "ShopFrequent": {
+      "name": "Task.ShopFrequent.name",
+      "help": "Task.ShopFrequent.help"
+    },
+    "ShopOnce": {
+      "name": "Task.ShopOnce.name",
+      "help": "Task.ShopOnce.help"
     },
     "Shipyard": {
       "name": "Task.Shipyard.name",

--- a/module/shop/shop_reward.py
+++ b/module/shop/shop_reward.py
@@ -46,7 +46,7 @@ class RewardShop(GachaUI, ShopUI, GeneralShop, GuildShop, MedalShop, MeritShop):
                 continue
             break
 
-    def run(self):
+    def run_frequent(self):
         self.ui_goto_shop()
 
         if self._shop_visit('general'):
@@ -54,31 +54,32 @@ class RewardShop(GachaUI, ShopUI, GeneralShop, GuildShop, MedalShop, MeritShop):
             if self.shop_bottom_navbar_ensure(left=5):
                 self._shop_repeat(shop_type='general')
 
-        if self.config.Scheduler_NextRun.hour == get_server_last_update('00:00').hour:
-            if self._shop_visit('merit'):
-                logger.hr('Merit shop', level=1)
-                if self.shop_bottom_navbar_ensure(left=4):
-                    self._shop_repeat(shop_type='merit')
+        self.config.task_delay(server_update=True)
 
-            if self._shop_visit('guild'):
-                logger.hr('Guild shop', level=1)
-                if self.shop_bottom_navbar_ensure(left=1):
-                    self._shop_repeat(shop_type='guild')
+    def run_once(self):
+        self.ui_goto_shop()
 
-            if self._shop_visit('medal'):
-                logger.hr('Medal shop', level=1)
-                self.ui_goto_gacha()
-                if self.gacha_side_navbar_ensure(bottom=2):
-                    for _ in [1, 2]:
-                        if self.gacha_bottom_navbar_ensure(left=_, is_build=False):
-                            self.shop_buy(shop_type='medal',
-                                          selection=self.config.MedalShop_Filter)
-                        else:
-                            logger.warning('Failed to arrive at expected '
-                                           'build interface for medal exchanges, '
-                                           f'left={_}, try again next time')
-        else:
-            logger.info(f'Next run {self.config.Scheduler_NextRun} is not at 00:00 (server time), '
-                        f'skip merit, guild and medal shops')
+        if self._shop_visit('merit'):
+            logger.hr('Merit shop', level=1)
+            if self.shop_bottom_navbar_ensure(left=4):
+                self._shop_repeat(shop_type='merit')
+
+        if self._shop_visit('guild'):
+            logger.hr('Guild shop', level=1)
+            if self.shop_bottom_navbar_ensure(left=1):
+                self._shop_repeat(shop_type='guild')
+
+        if self._shop_visit('medal'):
+            logger.hr('Medal shop', level=1)
+            self.ui_goto_gacha()
+            if self.gacha_side_navbar_ensure(bottom=2):
+                for _ in [1, 2]:
+                    if self.gacha_bottom_navbar_ensure(left=_, is_build=False):
+                        self.shop_buy(shop_type='medal',
+                                      selection=self.config.MedalShop_Filter)
+                    else:
+                        logger.warning('Failed to arrive at expected '
+                                       'build interface for medal exchanges, '
+                                       f'left={_}, try again next time')
 
         self.config.task_delay(server_update=True)


### PR DESCRIPTION
Due to general shop changing inventory 3 times daily, other shops 1 time daily

Simplify the date validating into splitting as 2 tasks differentiated by their `server update`

Primarily helps consistent task runs when not using Alas 24/7