### PR TITLE
ADD: CollectWeeklyMission

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -679,7 +679,8 @@
       "CollectOil": true,
       "CollectCoin": true,
       "CollectExp": true,
-      "CollectMission": true
+      "CollectMission": true,
+      "CollectWeeklyMission": true
     }
   },
   "ShopFrequent": {

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -3116,6 +3116,10 @@
       "CollectMission": {
         "type": "checkbox",
         "value": true
+      },
+      "CollectWeeklyMission": {
+        "type": "checkbox",
+        "value": true
       }
     }
   },

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -252,6 +252,7 @@ Reward:
   CollectCoin: true
   CollectExp: true
   CollectMission: true
+  CollectWeeklyMission: true
 GeneralShop:
   UseGems: false
   Refresh: false

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -179,6 +179,7 @@ class GeneratedConfig:
     Reward_CollectCoin = True
     Reward_CollectExp = True
     Reward_CollectMission = True
+    Reward_CollectWeeklyMission = True
 
     # Group `GeneralShop`
     GeneralShop_UseGems = False

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -992,6 +992,10 @@
     "CollectMission": {
       "name": "Collect Mission Rewards",
       "help": ""
+    },
+    "CollectWeeklyMission": {
+      "name": "Collect Weekly Mission Rewards",
+      "help": ""
     }
   },
   "GeneralShop": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -992,6 +992,10 @@
     "CollectMission": {
       "name": "Reward.CollectMission.name",
       "help": "Reward.CollectMission.help"
+    },
+    "CollectWeeklyMission": {
+      "name": "Reward.CollectWeeklyMission.name",
+      "help": "Reward.CollectWeeklyMission.help"
     }
   },
   "GeneralShop": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -992,6 +992,10 @@
     "CollectMission": {
       "name": "领取任务奖励",
       "help": ""
+    },
+    "CollectWeeklyMission": {
+      "name": "领取周任务奖励",
+      "help": ""
     }
   },
   "GeneralShop": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -992,6 +992,10 @@
     "CollectMission": {
       "name": "領取任務獎勵",
       "help": ""
+    },
+    "CollectWeeklyMission": {
+      "name": "領取周任務獎勵",
+      "help": ""
     }
   },
   "GeneralShop": {

--- a/module/reward/reward.py
+++ b/module/reward/reward.py
@@ -172,8 +172,13 @@ class Reward(UI):
         # premature exit
         return self._reward_mission_collect(interval=0)
 
-    def reward_mission(self):
+    def reward_mission(self, daily=True, weekly=True):
         """
+        Collects mission rewards
+        Args:
+            daily: If collect daily rewards
+            weekly: If collect weekly rewards
+
         Returns:
             bool: If rewarded.
 
@@ -181,6 +186,8 @@ class Reward(UI):
             in: page_main
             out: page_mission
         """
+        if not daily and not weekly:
+            return False
         logger.hr('Mission reward')
         if not self.appear(MISSION_NOTICE):
             logger.info('No mission reward')
@@ -190,10 +197,11 @@ class Reward(UI):
 
         self.ui_goto(page_mission, skip_first_screenshot=True)
 
-        # Handle all then weekly, key is both use
-        # different intervals
-        reward = self._reward_mission_all()
-        reward |= self._reward_mission_weekly()
+        reward = False
+        if daily:
+            reward |= self._reward_mission_all()
+        if weekly:
+            reward |= self._reward_mission_weekly()
 
         return reward
 
@@ -257,8 +265,7 @@ class Reward(UI):
             oil=self.config.Reward_CollectOil,
             coin=self.config.Reward_CollectCoin,
             exp=self.config.Reward_CollectExp)
-        if self.config.Reward_CollectMission:
-            self.ui_goto(page_main)
-            self.reward_mission()
-
+        self.reward_mission(self.config.Reward_CollectMission)
+        self.reward_mission(daily=self.config.Reward_CollectMission,
+                            weekly=self.config.Reward_CollectWeeklyMission)
         self.config.task_delay(success=True)


### PR DESCRIPTION
有个bug
如果领取任务奖励不勾选的话，领取周任务奖励，勾选也没用
不过这种场景不多吧
还是我要在help里说明一下？

还有，我把配置读取 `Reward_CollectWeeklyMission`写到了`reward_mission()`方法里面，是不是不太好，我看你配置是在`run()`里面读取判断的
```
        if self.config.Reward_CollectMission:
            self.ui_goto(page_main)
            self.reward_mission()
```
但是那样的话我就要传参给`reward_mission()`，感觉改动多不太好