### PR TITLE
Fix: Correct WarArchives's task delay logic

### DIFF
--- a/module/war_archives/war_archives.py
+++ b/module/war_archives/war_archives.py
@@ -15,6 +15,8 @@ class CampaignWarArchives(CampaignRun, CampaignBase):
             logger.info(f'Inventory: {current} / {total}, Remain: {current}')
             if remain == total:
                 logger.hr('Triggered out of data keys')
+                # Only triggered out of data keys can it delay the task
+                self.config.task_delay(server_update=True)
                 return True
 
         # Else, check other stop conditions
@@ -26,5 +28,4 @@ class CampaignWarArchives(CampaignRun, CampaignBase):
         backup.recover()
         self.ui_goto_main()  # Go to main, as remaining in page can throw off Event task
 
-        # Scheduler
-        self.config.task_delay(server_update=True)
+


### PR DESCRIPTION
不知道那个`self.ui_go_to_main()` 有必要留着吗？
我看你特地备注的，估计有用吧，没动他