### PR TITLE
添加心情控制>90的选项，保证部分船在后宅吃经验加成

### DIFF
--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -11,6 +11,7 @@ from module.logger import logger
 
 DIC_LIMIT = {
     'keep_exp_bonus': 120,
+    'keep_section_exp_bonus': 90,
     'prevent_green_face': 40,
     'prevent_yellow_face': 30,
     'prevent_red_face': 2,

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -472,6 +472,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -504,6 +505,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -805,6 +807,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -837,6 +840,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -1172,6 +1176,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -1204,6 +1209,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -1557,6 +1563,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -1589,6 +1596,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -1955,6 +1963,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -1987,6 +1996,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -2348,6 +2358,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -2380,6 +2391,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -2772,6 +2784,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -2804,6 +2817,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -3185,6 +3199,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -3217,6 +3232,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -3588,6 +3604,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -3620,6 +3637,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -3820,6 +3838,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -3852,6 +3871,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -4009,6 +4029,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -4041,6 +4062,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -5491,6 +5513,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -5523,6 +5546,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -5860,6 +5884,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"
@@ -5892,6 +5917,7 @@
         "value": "prevent_yellow_face",
         "option": [
           "keep_exp_bonus",
+          "keep_section_exp_bonus",
           "prevent_green_face",
           "prevent_yellow_face",
           "prevent_red_face"

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -136,7 +136,7 @@ Emotion:
   Fleet1Record: 2020-01-01 00:00:00
   Fleet1Control:
     value: prevent_yellow_face
-    option: [keep_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face]
+    option: [keep_exp_bonus, keep_section_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face]
   Fleet1Recover:
     value: not_in_dormitory
     option: [not_in_dormitory, dormitory_floor_1, dormitory_floor_2]
@@ -145,7 +145,7 @@ Emotion:
   Fleet2Record: 2020-01-01 00:00:00
   Fleet2Control:
     value: prevent_yellow_face
-    option: [keep_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face]
+    option: [keep_exp_bonus, keep_section_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face]
   Fleet2Recover:
     value: not_in_dormitory
     option: [not_in_dormitory, dormitory_floor_1, dormitory_floor_2]

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -100,12 +100,12 @@ class GeneratedConfig:
     Emotion_IgnoreLowEmotionWarn = False
     Emotion_Fleet1Value = 119
     Emotion_Fleet1Record = datetime.datetime(2020, 1, 1, 0, 0)
-    Emotion_Fleet1Control = 'prevent_yellow_face'  # keep_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face
+    Emotion_Fleet1Control = 'prevent_yellow_face'  # keep_exp_bonus, keep_section_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face
     Emotion_Fleet1Recover = 'not_in_dormitory'  # not_in_dormitory, dormitory_floor_1, dormitory_floor_2
     Emotion_Fleet1Oath = False
     Emotion_Fleet2Value = 119
     Emotion_Fleet2Record = datetime.datetime(2020, 1, 1, 0, 0)
-    Emotion_Fleet2Control = 'prevent_yellow_face'  # keep_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face
+    Emotion_Fleet2Control = 'prevent_yellow_face'  # keep_exp_bonus, keep_section_exp_bonus, prevent_green_face, prevent_yellow_face, prevent_red_face
     Emotion_Fleet2Recover = 'not_in_dormitory'  # not_in_dormitory, dormitory_floor_1, dormitory_floor_2
     Emotion_Fleet2Oath = False
 

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -732,6 +732,7 @@
       "name": "Fleet 1 Emotion Control",
       "help": "Measures will be taken to ensure control is maintained i.e. wait for recovery in level or stop current task if others can be executed while waiting",
       "keep_exp_bonus": "Keep Happy Bonus (>120)",
+      "keep_section_exp_bonus": "Keep Section Happy bonus (dorm>120 other>90)",
       "prevent_green_face": "Keep Content (>40)",
       "prevent_yellow_face": "Prevent Moody (>30)",
       "prevent_red_face": "Prevent Exhausted (>20)"
@@ -759,6 +760,7 @@
       "name": "Fleet 2 Emotion Control",
       "help": "Measures will be taken to ensure control is maintained i.e. wait for recovery in level or stop current task if others can be executed while waiting",
       "keep_exp_bonus": "Keep Happy Bonus (>120)",
+      "keep_section_exp_bonus": "Keep Section Happy bonus (dorm>120 other>90)",
       "prevent_green_face": "Keep Content (>40)",
       "prevent_yellow_face": "Prevent Moody (>30)",
       "prevent_red_face": "Prevent Exhausted (>20)"

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -732,6 +732,7 @@
       "name": "Emotion.Fleet1Control.name",
       "help": "Emotion.Fleet1Control.help",
       "keep_exp_bonus": "keep_exp_bonus",
+      "keep_section_exp_bonus": "keep_section_exp_bonus",
       "prevent_green_face": "prevent_green_face",
       "prevent_yellow_face": "prevent_yellow_face",
       "prevent_red_face": "prevent_red_face"
@@ -759,6 +760,7 @@
       "name": "Emotion.Fleet2Control.name",
       "help": "Emotion.Fleet2Control.help",
       "keep_exp_bonus": "keep_exp_bonus",
+      "keep_section_exp_bonus": "keep_section_exp_bonus",
       "prevent_green_face": "prevent_green_face",
       "prevent_yellow_face": "prevent_yellow_face",
       "prevent_red_face": "prevent_red_face"

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -732,6 +732,7 @@
       "name": "一队心情控制",
       "help": "",
       "keep_exp_bonus": "保持经验加成 (>120)",
+      "keep_section_exp_bonus": "保持部分船经验加成 (后宅船>120,其他>90)",
       "prevent_green_face": "防止绿脸 (>40)",
       "prevent_yellow_face": "防止黄脸 (>30)",
       "prevent_red_face": "防止红脸 (>0)"
@@ -759,6 +760,7 @@
       "name": "二队心情控制",
       "help": "",
       "keep_exp_bonus": "保持经验加成 (>120)",
+      "keep_section_exp_bonus": "保持部分船经验加成 (后宅船>120,其他>90)",
       "prevent_green_face": "防止绿脸 (>40)",
       "prevent_yellow_face": "防止黄脸 (>30)",
       "prevent_red_face": "防止红脸 (>0)"

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -732,6 +732,7 @@
       "name": "一隊心情控制",
       "help": "",
       "keep_exp_bonus": "保持經驗加成 (>120)",
+      "keep_section_exp_bonus": "keep_section_exp_bonus",
       "prevent_green_face": "防止綠臉 (>40)",
       "prevent_yellow_face": "防止黃臉 (>30)",
       "prevent_red_face": "防止紅臉 (>0)"
@@ -759,6 +760,7 @@
       "name": "二隊心情控制",
       "help": "",
       "keep_exp_bonus": "保持經驗加成 (>120)",
+      "keep_section_exp_bonus": "keep_section_exp_bonus",
       "prevent_green_face": "防止綠臉 (>40)",
       "prevent_yellow_face": "防止黃臉 (>30)",
       "prevent_red_face": "防止紅臉 (>0)"


### PR DESCRIPTION
心情90临界点的控制，150-120=120-90，刚好消耗30的心情。
可以保证后宅船吃到经验加成。