### PR TITLE
Fix: Adding semantics to str input of num type

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -196,11 +196,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -2532,11 +2534,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -2647,7 +2651,8 @@
     "StopCondition": {
       "RunCount": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
@@ -2675,7 +2680,8 @@
       },
       "ReachLevel": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -2954,11 +2960,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -3069,7 +3077,8 @@
     "StopCondition": {
       "RunCount": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
@@ -3097,7 +3106,8 @@
       },
       "ReachLevel": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -3376,11 +3386,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -3480,7 +3492,8 @@
     "StopCondition": {
       "RunCount": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
@@ -3508,7 +3521,8 @@
       },
       "ReachLevel": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -3894,7 +3908,8 @@
       },
       "ReachLevel": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Emotion": {
@@ -3991,11 +4006,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4058,7 +4075,8 @@
     "StopCondition": {
       "RunCount": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
@@ -4086,7 +4104,8 @@
       },
       "ReachLevel": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Emotion": {
@@ -4183,11 +4202,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4218,11 +4239,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4257,11 +4280,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4318,11 +4343,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4392,11 +4419,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 278
+        "value": 278,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 278
+        "value": 278,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4435,11 +4464,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4502,11 +4533,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4573,11 +4606,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": "60-120"
+        "value": "60-120",
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": "60-120"
+        "value": "60-120",
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4624,11 +4659,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4671,11 +4708,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4855,11 +4894,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4901,11 +4942,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4963,11 +5006,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -4992,11 +5037,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5027,11 +5074,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5062,11 +5111,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5097,11 +5148,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5230,11 +5283,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5273,11 +5328,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5344,11 +5401,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -5415,7 +5474,8 @@
     "StopCondition": {
       "RunCount": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
@@ -5443,7 +5503,8 @@
       },
       "ReachLevel": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -5722,11 +5783,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6144,11 +6207,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6180,11 +6245,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6240,11 +6307,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6275,11 +6344,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6330,11 +6401,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 60
+        "value": 60,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 60
+        "value": 60,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6381,11 +6454,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 60
+        "value": 60,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 60
+        "value": 60,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6422,11 +6497,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 60
+        "value": 60,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 60
+        "value": 60,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",
@@ -6463,11 +6540,13 @@
       },
       "SuccessInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "disable",
-        "value": 30
+        "value": 30,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "disable",

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -3,8 +3,7 @@
     "Emulator": {
       "Serial": {
         "type": "input",
-        "value": "127.0.0.1:5555",
-        "valuetype": "str"
+        "value": "127.0.0.1:5555"
       },
       "PackageName": {
         "type": "input",
@@ -57,21 +56,25 @@
       },
       "ScreenshotLength": {
         "type": "input",
-        "value": 1
+        "value": 1,
+        "validate": "int"
       }
     },
     "Optimization": {
       "ScreenshotInterval": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "CombatScreenshotInterval": {
         "type": "input",
-        "value": 1.0
+        "value": 1.0,
+        "validate": "float"
       },
       "TaskHoardingDuration": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "WhenTaskQueueEmpty": {
         "type": "select",
@@ -155,7 +158,8 @@
       },
       "EnhanceCheckPerCategory": {
         "type": "input",
-        "value": 2
+        "value": 2,
+        "validate": "int"
       },
       "OldRetireN": {
         "type": "checkbox",
@@ -221,11 +225,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -276,11 +282,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "select",
@@ -303,7 +311,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -461,7 +470,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -493,7 +503,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -539,7 +550,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -547,15 +559,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     },
     "EnemyPriority": {
@@ -587,11 +602,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -648,11 +665,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -675,7 +694,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -794,7 +814,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -826,7 +847,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -872,7 +894,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -880,15 +903,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -909,11 +935,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -976,11 +1004,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -1003,7 +1033,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -1161,7 +1192,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -1193,7 +1225,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -1239,7 +1272,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -1247,15 +1281,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -1276,11 +1313,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -1361,11 +1400,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -1388,7 +1429,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -1546,7 +1588,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -1578,7 +1621,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -1624,7 +1668,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -1632,15 +1677,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -1661,11 +1709,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -1799,11 +1849,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -1826,7 +1878,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -1945,7 +1998,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -1977,7 +2031,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -2024,7 +2079,8 @@
     "EventGeneral": {
       "PtLimit": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "TimeLimit": {
         "type": "input",
@@ -2050,11 +2106,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -2154,11 +2212,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "select",
@@ -2181,7 +2241,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -2339,7 +2400,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -2371,7 +2433,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -2417,7 +2480,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -2425,15 +2489,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     },
     "EnemyPriority": {
@@ -2483,7 +2550,8 @@
       },
       "LastStage": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Campaign": {
@@ -2583,7 +2651,8 @@
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -2764,7 +2833,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -2796,7 +2866,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -2842,7 +2913,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -2850,15 +2922,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -2897,7 +2972,8 @@
       },
       "LastStage": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Campaign": {
@@ -2997,7 +3073,8 @@
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -3178,7 +3255,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -3210,7 +3288,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -3256,7 +3335,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -3264,15 +3344,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -3401,7 +3484,8 @@
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -3582,7 +3666,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -3614,7 +3699,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -3660,7 +3746,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -3668,15 +3755,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -3697,11 +3787,13 @@
       },
       "SuccessInterval": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "FailureInterval": {
         "type": "input",
-        "value": 120
+        "value": 120,
+        "validate": "int"
       },
       "ServerUpdate": {
         "type": "input",
@@ -3773,11 +3865,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -3814,7 +3908,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -3846,7 +3941,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -3966,7 +4062,8 @@
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -4003,7 +4100,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -4035,7 +4133,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -4182,19 +4281,23 @@
       },
       "T4Allow": {
         "type": "input",
-        "value": 100
+        "value": 100,
+        "validate": "int"
       },
       "T3Allow": {
         "type": "input",
-        "value": 100
+        "value": 100,
+        "validate": "int"
       },
       "T2Allow": {
         "type": "input",
-        "value": 200
+        "value": 200,
+        "validate": "int"
       },
       "T1Allow": {
         "type": "input",
-        "value": 200
+        "value": 200,
+        "validate": "int"
       }
     }
   },
@@ -4346,7 +4449,8 @@
     "Meowfficer": {
       "BuyAmount": {
         "type": "input",
-        "value": 1
+        "value": 1,
+        "validate": "int"
       },
       "FortChoreMeowfficer": {
         "type": "checkbox",
@@ -4376,7 +4480,8 @@
       },
       "EnhanceIndex": {
         "type": "input",
-        "value": 1
+        "value": 1,
+        "validate": "int"
       }
     }
   },
@@ -4433,11 +4538,13 @@
       },
       "NewOperationMaxDate": {
         "type": "input",
-        "value": 15
+        "value": 15,
+        "validate": "int"
       },
       "JoinThreshold": {
         "type": "input",
-        "value": 1
+        "value": 1,
+        "validate": "int"
       },
       "AttackBoss": {
         "type": "checkbox",
@@ -4762,15 +4869,18 @@
     "Shipyard": {
       "ResearchSeries": {
         "type": "input",
-        "value": 1
+        "value": 1,
+        "validate": "int"
       },
       "ShipIndex": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "BuyAmount": {
         "type": "input",
-        "value": 2
+        "value": 2,
+        "validate": "int"
       }
     }
   },
@@ -5187,23 +5297,28 @@
       },
       "OpponentTrial": {
         "type": "input",
-        "value": 1
+        "value": 1,
+        "validate": "int"
       },
       "ExercisePreserve": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "LowHpThreshold": {
         "type": "input",
-        "value": 0.4
+        "value": 0.4,
+        "validate": "float"
       },
       "LowHpConfirmWait": {
         "type": "input",
-        "value": 0.1
+        "value": 0.1,
+        "validate": "float"
       },
       "OpponentRefreshValue": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OpponentRefreshRecord": {
         "type": "input",
@@ -5304,7 +5419,8 @@
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "disable",
@@ -5485,7 +5601,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -5517,7 +5634,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -5563,7 +5681,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -5571,15 +5690,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -5669,11 +5791,13 @@
     "StopCondition": {
       "RunCount": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "MapAchievement": {
         "type": "select",
@@ -5696,7 +5820,8 @@
       },
       "ReachLevel": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "Fleet": {
@@ -5854,7 +5979,8 @@
       },
       "Fleet1Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet1Record": {
         "type": "input",
@@ -5886,7 +6012,8 @@
       },
       "Fleet2Value": {
         "type": "input",
-        "value": 119
+        "value": 119,
+        "validate": "int"
       },
       "Fleet2Record": {
         "type": "input",
@@ -5932,7 +6059,8 @@
       },
       "HpBalanceThreshold": {
         "type": "input",
-        "value": 0.2
+        "value": 0.2,
+        "validate": "float"
       },
       "HpBalanceWeight": {
         "type": "input",
@@ -5940,15 +6068,18 @@
       },
       "RepairUseSingleThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       },
       "RepairUseMultiThreshold": {
         "type": "input",
-        "value": 0.6
+        "value": 0.6,
+        "validate": "float"
       },
       "LowHpRetreatThreshold": {
         "type": "input",
-        "value": 0.3
+        "value": 0.3,
+        "validate": "float"
       }
     }
   },
@@ -5964,11 +6095,13 @@
       },
       "OilLimit": {
         "type": "input",
-        "value": 1000
+        "value": 1000,
+        "validate": "int"
       },
       "RepairThreshold": {
         "type": "input",
-        "value": 0.4
+        "value": 0.4,
+        "validate": "float"
       },
       "BuyAkashiShop": {
         "type": "checkbox",
@@ -6025,7 +6158,8 @@
     "OpsiAshAssist": {
       "Tier": {
         "type": "input",
-        "value": 15
+        "value": 15,
+        "validate": "int"
       }
     }
   },
@@ -6068,7 +6202,8 @@
       },
       "LastZone": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "OpsiFleet": {
@@ -6342,7 +6477,8 @@
     "OpsiMeowfficerFarming": {
       "ActionPointPreserve": {
         "type": "input",
-        "value": 500
+        "value": 500,
+        "validate": "int"
       },
       "HazardLevel": {
         "type": "select",
@@ -6357,7 +6493,8 @@
       },
       "TargetZone": {
         "type": "input",
-        "value": 0
+        "value": 0,
+        "validate": "int"
       }
     },
     "OpsiFleet": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -12,9 +12,7 @@ Scheduler:
   FailureInterval: 120
   ServerUpdate: 00:00
 Emulator:
-  Serial:
-    value: 127.0.0.1:5555
-    valuetype: str
+  Serial: 127.0.0.1:5555
   PackageName: com.bilibili.azurlane
   Server:
     value: cn

--- a/module/config/config_updater.py
+++ b/module/config/config_updater.py
@@ -81,6 +81,10 @@ class ConfigGenerator:
             arg['type'] = data_to_type(value, arg=path[1])
             if isinstance(value['value'], datetime):
                 arg['validate'] = 'datetime'
+            elif arg['type'] == 'input' and isinstance(value['value'], int):
+                arg['validate'] = 'int'
+            elif arg['type'] == 'input' and isinstance(value['value'], float):
+                arg['validate'] = 'float'
             # Manual definition has the highest priority
             arg.update(value)
             deep_set(data, keys=path, value=arg)

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -444,8 +444,7 @@ class AlasGUI(Frame):
                 except queue.Empty:
                     config = read_file(filepath_config(config_name))
                     for k, v in modified.copy().items():
-                        valuetype = deep_get(self.ALAS_ARGS, k + ".valuetype")
-                        v = parse_pin_value(v, valuetype)
+                        v = parse_pin_value(v)
                         validate = deep_get(self.ALAS_ARGS, k + ".validate")
                         if not len(str(v)):
                             default = deep_get(self.ALAS_ARGS, k + ".value")
@@ -453,6 +452,10 @@ class AlasGUI(Frame):
                             valid.append(self.path_to_idx[k])
                             modified[k] = default
                         elif not validate or re_fullmatch(validate, v):
+                            v={
+                                "int": int,
+                                "float": float,
+                            }.get(validate, lambda x: x)(v)
                             deep_set(config, k, v)
                             valid.append(self.path_to_idx[k])
                         else:

--- a/module/webui/utils.py
+++ b/module/webui/utils.py
@@ -19,12 +19,12 @@ from pywebio.session import register_thread, run_js
 from rich.console import Console, ConsoleOptions
 from rich.terminal_theme import TerminalTheme
 
-RE_DATETIME = (
-    r"(\d{2}|\d{4})(?:\-)?([0]{1}\d{1}|[1]{1}[0-2]{1})(?:\-)?"
-    + r"([0-2]{1}\d{1}|[3]{1}[0-1]{1})(?:\s)?([0-1]{1}\d{1}|[2]"
-    + r"{1}[0-3]{1})(?::)?([0-5]{1}\d{1})(?::)?([0-5]{1}\d{1})"
-)
-
+RE_DATETIME = \
+    r"(\d{2}|\d{4})(?:\-)?([0]{1}\d{1}|[1]{1}[0-2]{1})(?:\-)?" \
+    r"([0-2]{1}\d{1}|[3]{1}[0-1]{1})(?:\s)?([0-1]{1}\d{1}|[2]" \
+    r"{1}[0-3]{1})(?::)?([0-5]{1}\d{1})(?::)?([0-5]{1}\d{1})"
+RE_INT = r"\d+"
+RE_FLOAT = r"\d*\.?\d+|\d+\.\d*" # reject scientific counting
 
 TRACEBACK_CODE_FORMAT = """\
 <code class="rich-traceback">
@@ -391,38 +391,15 @@ class Icon:
     ADD = _read(filepath_icon("add"))
 
 
-str2type = {
-    "str": str,
-    "float": float,
-    "int": int,
-    "bool": bool,
-}
-
-
-def parse_pin_value(val, valuetype: str = None):
+def parse_pin_value(val):
     """
     input, textarea return str
     select return its option (str or int)
-    checkbox return [] or [True] (define in put_checkbox_)
+    checkbox return [] or [True] (define in put_checkbox_) which needs to be converted to bool
     """
     if isinstance(val, list):
-        if len(val) == 0:
-            return False
-        else:
-            return True
-    elif valuetype:
-        return str2type[valuetype](val)
-    elif isinstance(val, (int, float)):
-        return val
-    else:
-        try:
-            v = float(val)
-        except ValueError:
-            return val
-        if v.is_integer():
-            return int(v)
-        else:
-            return v
+        return bool(val)
+    return val
 
 
 def login(password):
@@ -452,9 +429,11 @@ def get_localstorage(key):
 
 
 def re_fullmatch(pattern, string):
-    if pattern == "datetime":
-        pattern = RE_DATETIME
-    # elif:
+    pattern = {
+        "datetime": RE_DATETIME,
+        "int": RE_INT,
+        "float": RE_FLOAT
+    }.get(pattern, pattern)
     return re.fullmatch(pattern=pattern, string=string)
 
 


### PR DESCRIPTION
Yesterday, the serial number `27e834120906` of one of my phones has been interpreted and stored as a float, and alas crashed.  
I think it's stupid to decide on data types based on literal values alone without looking at the actual semantics.  
Notice that some items in args have `validate` field to ~~determine it to datetime~~ reject invalid input.  
So I use this field to tell int/float while items without this field will keep as a string.  
This pr makes it necessary to specify `validate` field as int/float for numeric inputs added later.  
Btw, only non-negative inputs are accepted now.  