### PR TITLE
Fix: add [at]wraps to retry_wrapper to display actual function name in benchmark log output

### DIFF
--- a/module/device/method/ascreencap.py
+++ b/module/device/method/ascreencap.py
@@ -1,4 +1,5 @@
 import os
+from functools import wraps
 
 import lz4.block
 from adbutils.errors import AdbError
@@ -15,6 +16,7 @@ class AscreencapError(Exception):
 
 
 def retry(func):
+    @wraps(func)
     def retry_wrapper(self, *args, **kwargs):
         """
         Args:

--- a/module/device/method/hermit.py
+++ b/module/device/method/hermit.py
@@ -1,4 +1,5 @@
 import json
+from functools import wraps
 
 import requests
 from adbutils.errors import AdbError
@@ -17,6 +18,7 @@ class HermitError(Exception):
 
 
 def retry(func):
+    @wraps(func)
     def retry_wrapper(self, *args, **kwargs):
         """
         Args:

--- a/module/device/method/minitouch.py
+++ b/module/device/method/minitouch.py
@@ -1,5 +1,6 @@
 import socket
 import time
+from functools import wraps
 
 from adbutils.errors import AdbError
 
@@ -180,6 +181,7 @@ class MinitouchOccupiedError(Exception):
 
 
 def retry(func):
+    @wraps(func)
     def retry_wrapper(self, *args, **kwargs):
         """
         Args:

--- a/module/device/method/uiautomator_2.py
+++ b/module/device/method/uiautomator_2.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from json.decoder import JSONDecodeError
 
 import uiautomator2 as u2
@@ -13,6 +14,7 @@ from module.logger import logger
 
 
 def retry(func):
+    @wraps(func)
     def retry_wrapper(self, *args, **kwargs):
         """
         Args:

--- a/module/device/method/wsa.py
+++ b/module/device/method/wsa.py
@@ -1,4 +1,5 @@
 import re
+from functools import wraps
 
 from adbutils.errors import AdbError
 
@@ -9,6 +10,7 @@ from module.logger import logger
 
 
 def retry(func):
+    @wraps(func)
     def retry_wrapper(self, *args, **kwargs):
         """
         Args:


### PR DESCRIPTION
It's weird to see a `retry_wrapper` while running benchmark  
before:  
![image](https://user-images.githubusercontent.com/40085173/163131212-0854ebb5-f97c-40d4-a84d-4b72360636f9.png)  
after:  
![image](https://user-images.githubusercontent.com/40085173/163131420-2458e213-2e2d-48f0-8160-f5f9f1819d88.png)  
我是废物,我连分支切换都搞不定  