### PR TITLE
Fix: Add timeout to ADB and aScreencap screenshot

### DIFF
--- a/module/device/method/utils.py
+++ b/module/device/method/utils.py
@@ -49,6 +49,7 @@ def recv_all(stream, chunk_size=4096) -> bytes:
     """
     if isinstance(stream, _AdbStreamConnection):
         stream = stream.conn
+        stream.settimeout(10)
 
     try:
         fragments = []


### PR DESCRIPTION
`ascreencap.py` line 166 `Ascreencap.screenshot_ascreencap` passed `stream=True` param to `adb_shell` which finally called `AdbClient.shell` in `adbutils`  
But timeout is only set when `stream is False` (`adbutils/__init__.py` line 335 `AdbClient.shell`), so actually the next step `recv_all` will run without timeout protection  
When `recv_all` takes a `Socket` (only in `Connection.adb_shell_nc`), it has already set a timeout before calling  
So the `settimeout` statement is added under the case of taking an `_AdbStreamConnection` object, which affects on ADB and aScreencap screenshot methods