### PR TITLE
Fix: An accidental exception causes the commission to fail

### DIFF
--- a/module/commission/commission.py
+++ b/module/commission/commission.py
@@ -379,6 +379,8 @@ class RewardCommission(UI, InfoHandler):
 
             if failed:
                 logger.warning(f'Failed to select commission: {comm}')
+                self._commission_mode_reset()
+                self._commission_swipe_to_top()
                 self.device.click_record_clear()
                 continue
             else:


### PR DESCRIPTION
alas在滑动异常导致的一轮委托识别失效后不会重置委托界面状态，
导致第二轮委托识别只会识别最下几个委托，
如果目标委托在靠上的位置则永远识别不到，
这个pr补充了在一轮识别失败后重置界面的部分