### PR TITLE
Fix: Non-Windows OS Uncensored Patch error

### DIFF
--- a/module/daemon/uncensored.py
+++ b/module/daemon/uncensored.py
@@ -1,6 +1,6 @@
 import builtins
 
-from deploy.installer import GitManager
+from deploy.git import GitManager
 from deploy.utils import *
 from module.handler.login import LoginHandler
 from module.logger import logger


### PR DESCRIPTION
When I try to use Uncensored Patch in Linux, alas reports an error saying `no module named winreg`.  
emmm, Linux definitely doesn't have winreg, and I found out that Uncensored Patch doesn't even need winreg.
winreg is indirectly imported by `deploy.installer` when importing `GitManager`, which can be directly imported by `deploy.git`, just like other code in alas.