### PR TITLE
Add: new setting makes research more stable

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -4240,6 +4240,7 @@
         "option": [
           "always_use",
           "only_05_hour",
+          "only_no_project",
           "do_not_use"
         ]
       },
@@ -4249,6 +4250,7 @@
         "option": [
           "always_use",
           "only_05_hour",
+          "only_no_project",
           "do_not_use"
         ]
       },
@@ -4258,6 +4260,7 @@
         "option": [
           "always_use",
           "only_05_hour",
+          "only_no_project",
           "do_not_use"
         ]
       },

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -254,13 +254,13 @@ ControlExpOverflow:
 Research:
   UseCube:
     value: only_05_hour
-    option: [always_use, only_05_hour, do_not_use]
+    option: [always_use, only_05_hour, only_no_project, do_not_use]
   UseCoin:
     value: always_use
-    option: [always_use, only_05_hour, do_not_use]
+    option: [always_use, only_05_hour, only_no_project, do_not_use]
   UsePart:
     value: always_use
-    option: [always_use, only_05_hour, do_not_use]
+    option: [always_use, only_05_hour, only_no_project, do_not_use]
   PresetFilter:
     value: series_4_blueprint_tenrai
     option:

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -180,9 +180,9 @@ class GeneratedConfig:
     ControlExpOverflow_T1Allow = 200
 
     # Group `Research`
-    Research_UseCube = 'only_05_hour'  # always_use, only_05_hour, do_not_use
-    Research_UseCoin = 'always_use'  # always_use, only_05_hour, do_not_use
-    Research_UsePart = 'always_use'  # always_use, only_05_hour, do_not_use
+    Research_UseCube = 'only_05_hour'  # always_use, only_05_hour, only_no_project, do_not_use
+    Research_UseCoin = 'always_use'  # always_use, only_05_hour, only_no_project, do_not_use
+    Research_UsePart = 'always_use'  # always_use, only_05_hour, only_no_project, do_not_use
     Research_PresetFilter = 'series_4_blueprint_tenrai'  # custom, series_4_blueprint_tenrai, series_4_blueprint_only, series_4_tenrai_only, series_3, series_3_than_2
     Research_CustomFilter = 'S4-Q0.5 > Q-0.5 > S4-DR0.5 > S4-PRY0.5 > DR-0.5 > PRY-0.5\n> S4-Q1 > S4-Q2\n> S4-DR2.5 > S4-G1.5\n> S4-Q4 > S4-H0.5 > S4-G4\n> S4-PRY2.5 > S4-G2.5\n> reset > S4-H1 > shortest'
 

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -473,6 +473,7 @@
       "name": "Event Name",
       "help": "Automatically selects to the latest event",
       "campaign_main": "campaign_main",
+      "raid_20200624": "Air Raid Drills with Essex Rerun",
       "event_20220428_cn": "Rondo at Rainbows End",
       "event_20220414_cn": "Aurora Noctis Rerun",
       "event_20220407_tw": "蒼紅的迴響(復刻)",
@@ -515,7 +516,6 @@
       "event_20201002_en": "Counterattack Within the Fjord",
       "event_20200820_cn": "Scherzo of Iron and Blood Rerun",
       "event_20200716_en": "Ink Stained Steel Sakura Rerun",
-      "raid_20200624": "Air Raid Drills with Essex Rerun",
       "event_20200611_en": "Skybound Oratorio",
       "event_20200603_en": "Prelude under the Moon Rerun",
       "event_20200521_en": "Iris of Light and Dark Rerun",
@@ -1070,21 +1070,24 @@
       "name": "Use Cube",
       "help": "Allow to undertake projects that require cubes",
       "always_use": "Always Use",
-      "only_05_hour": "Only 0.5 Hour Researches",
+      "only_05_hour": "0.5 Hour+No project available",
+      "only_no_project": "Only no project available",
       "do_not_use": "Don't Use"
     },
     "UseCoin": {
       "name": "Use Coin",
       "help": "Allow to undertake projects that require coins",
       "always_use": "Always Use",
-      "only_05_hour": "Only 0.5 Hour Researches",
+      "only_05_hour": "0.5 Hour+No project available",
+      "only_no_project": "Only no project available",
       "do_not_use": "Don't Use"
     },
     "UsePart": {
       "name": "Use Part/Plate",
       "help": "Allow to undertake projects that require parts/plates",
       "always_use": "Always Use",
-      "only_05_hour": "Only 0.5 Hour Researches",
+      "only_05_hour": "0.5 Hour+No project available",
+      "only_no_project": "Only no project available",
       "do_not_use": "Don't Use"
     },
     "PresetFilter": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -473,6 +473,7 @@
       "name": "Campaign.Event.name",
       "help": "Campaign.Event.help",
       "campaign_main": "campaign_main",
+      "raid_20200624": "特別演習超空強襲波（復刻）",
       "event_20220428_cn": "吟ずる瑠璃の楽章",
       "event_20220414_cn": "極夜照らす幻光（復刻）",
       "event_20220407_tw": "蒼紅的迴響(復刻)",
@@ -515,7 +516,6 @@
       "event_20201002_en": "Counterattack Within the Fjord",
       "event_20200820_cn": "黒鉄の楽章 誓いの海（復刻）",
       "event_20200716_en": "Ink Stained Steel Sakura Rerun",
-      "raid_20200624": "特別演習超空強襲波（復刻）",
       "event_20200611_en": "Skybound Oratorio",
       "event_20200603_en": "Prelude under the Moon Rerun",
       "event_20200521_en": "Iris of Light and Dark Rerun",
@@ -1071,6 +1071,7 @@
       "help": "Research.UseCube.help",
       "always_use": "always_use",
       "only_05_hour": "only_05_hour",
+      "only_no_project": "only_no_project",
       "do_not_use": "do_not_use"
     },
     "UseCoin": {
@@ -1078,6 +1079,7 @@
       "help": "Research.UseCoin.help",
       "always_use": "always_use",
       "only_05_hour": "only_05_hour",
+      "only_no_project": "only_no_project",
       "do_not_use": "do_not_use"
     },
     "UsePart": {
@@ -1085,6 +1087,7 @@
       "help": "Research.UsePart.help",
       "always_use": "always_use",
       "only_05_hour": "only_05_hour",
+      "only_no_project": "only_no_project",
       "do_not_use": "do_not_use"
     },
     "PresetFilter": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -473,6 +473,7 @@
       "name": "活动名称",
       "help": "自动选择至最新的活动",
       "campaign_main": "主线图",
+      "raid_20200624": "复刻特别演习埃塞克斯级",
       "event_20220428_cn": "虹彩的终幕曲",
       "event_20220414_cn": "复刻永夜幻光",
       "event_20220407_tw": "蒼紅的迴響(復刻)",
@@ -515,7 +516,6 @@
       "event_20201002_en": "Counterattack Within the Fjord",
       "event_20200820_cn": "复刻铁血音符誓言",
       "event_20200716_en": "Ink Stained Steel Sakura Rerun",
-      "raid_20200624": "复刻特别演习埃塞克斯级",
       "event_20200611_en": "Skybound Oratorio",
       "event_20200603_en": "Prelude under the Moon Rerun",
       "event_20200521_en": "Iris of Light and Dark Rerun",
@@ -1070,21 +1070,24 @@
       "name": "使用魔方",
       "help": "",
       "always_use": "总是使用",
-      "only_05_hour": "仅0.5小时科研使用",
+      "only_05_hour": "0.5小时+无项目可做时",
+      "only_no_project": "无项目可做时",
       "do_not_use": "不使用"
     },
     "UseCoin": {
       "name": "使用物资",
       "help": "",
       "always_use": "总是使用",
-      "only_05_hour": "仅0.5小时科研使用",
+      "only_05_hour": "0.5小时+无项目可做时",
+      "only_no_project": "无项目可做时",
       "do_not_use": "不使用"
     },
     "UsePart": {
       "name": "使用部件",
       "help": "",
       "always_use": "总是使用",
-      "only_05_hour": "仅0.5小时科研使用",
+      "only_05_hour": "0.5小时+无项目可做时",
+      "only_no_project": "无项目可做时",
       "do_not_use": "不使用"
     },
     "PresetFilter": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -473,6 +473,7 @@
       "name": "活動名稱",
       "help": "自動選擇至最新的活動圖",
       "campaign_main": "主線圖",
+      "raid_20200624": "特別演習埃塞克斯級(復刻)",
       "event_20220428_cn": "Rondo at Rainbows End",
       "event_20220414_cn": "Aurora Noctis Rerun",
       "event_20220407_tw": "蒼紅的迴響(復刻)",
@@ -515,7 +516,6 @@
       "event_20201002_en": "Counterattack Within the Fjord",
       "event_20200820_cn": "Scherzo of Iron and Blood Rerun",
       "event_20200716_en": "Ink Stained Steel Sakura Rerun",
-      "raid_20200624": "特別演習埃塞克斯級",
       "event_20200611_en": "Skybound Oratorio",
       "event_20200603_en": "Prelude under the Moon Rerun",
       "event_20200521_en": "Iris of Light and Dark Rerun",
@@ -1070,21 +1070,24 @@
       "name": "使用魔方",
       "help": "",
       "always_use": "總是使用",
-      "only_05_hour": "僅0.5小時科研使用",
+      "only_05_hour": "0.5小時+無項目可做時",
+      "only_no_project": "無項目可做時",
       "do_not_use": "不使用"
     },
     "UseCoin": {
       "name": "使用物資",
       "help": "",
       "always_use": "總是使用",
-      "only_05_hour": "僅0.5小時科研使用",
+      "only_05_hour": "0.5小時+無項目可做時",
+      "only_no_project": "無項目可做時",
       "do_not_use": "不使用"
     },
     "UsePart": {
       "name": "使用部件",
       "help": "",
       "always_use": "總是使用",
-      "only_05_hour": "僅0.5小時科研使用",
+      "only_05_hour": "0.5小時+無項目可做時",
+      "only_no_project": "無項目可做時",
       "do_not_use": "不使用"
     },
     "PresetFilter": {

--- a/module/research/project.py
+++ b/module/research/project.py
@@ -571,7 +571,7 @@ class ResearchSelector(UI):
 
         self.projects = projects
 
-    def research_sort_filter(self):
+    def research_sort_filter(self, enforce):
         """
         Returns:
             list: A list of ResearchProject objects and preset strings,
@@ -596,10 +596,8 @@ class ResearchSelector(UI):
         string = string.lower().replace('hakuryuu', 'hakuryu')
 
         FILTER.load(string)
-        priority = FILTER.apply(self.projects, func=self._research_check)
-        if not [project for project in priority
-                if project != 'reset' and project != 'shortest' and project != 'cheapest']:
-            priority = FILTER.apply(self.projects, func=partial(self._research_check, enforce=True))
+        priority = FILTER.apply(self.projects, func=partial(self._research_check, enforce=enforce))
+
         # Log
         logger.attr('Filter_sort', ' > '.join([str(project) for project in priority]))
         return priority
@@ -661,26 +659,26 @@ class ResearchSelector(UI):
 
         return True
 
-    def research_sort_shortest(self):
+    def research_sort_shortest(self, enforce):
         """
         Returns:
             list: A list of ResearchProject objects and preset strings,
                 such as [object, object, object, 'reset']
         """
         FILTER.load(FILTER_STRING_SHORTEST)
-        priority = FILTER.apply(self.projects, func=self._research_check)
+        priority = FILTER.apply(self.projects, func=partial(self._research_check, enforce=enforce))
 
         logger.attr('Filter_sort', ' > '.join([str(project) for project in priority]))
         return priority
 
-    def research_sort_cheapest(self):
+    def research_sort_cheapest(self, enforce):
         """
         Returns:
             list: A list of ResearchProject objects and preset strings,
                 such as [object, object, object, 'reset']
         """
         FILTER.load(FILTER_STRING_CHEAPEST)
-        priority = FILTER.apply(self.projects, func=self._research_check)
+        priority = FILTER.apply(self.projects, func=partial(self._research_check, enforce=enforce))
 
         logger.attr('Filter_sort', ' > '.join([str(project) for project in priority]))
         return priority

--- a/module/research/project.py
+++ b/module/research/project.py
@@ -1,5 +1,6 @@
 import re
 from datetime import timedelta
+from functools import partial
 
 from scipy import signal
 
@@ -596,16 +597,18 @@ class ResearchSelector(UI):
 
         FILTER.load(string)
         priority = FILTER.apply(self.projects, func=self._research_check)
-
+        if not [project for project in priority
+                if project != 'reset' and project != 'shortest' and project != 'cheapest']:
+            priority = FILTER.apply(self.projects, func=partial(self._research_check, enforce=True))
         # Log
         logger.attr('Filter_sort', ' > '.join([str(project) for project in priority]))
         return priority
 
-    def _research_check(self, project):
+    def _research_check(self, project, enforce=False):
         """
         Args:
             project (ResearchProject):
-
+            enforce (Bool):
         Returns:
             bool:
         """
@@ -617,17 +620,23 @@ class ResearchSelector(UI):
         if project.need_cube:
             if self.config.Research_UseCube == 'do_not_use':
                 return False
-            if self.config.Research_UseCube == 'only_05_hour' and not is_05:
+            if self.config.Research_UseCube == 'only_no_project' and not enforce:
+                return False
+            if self.config.Research_UseCube == 'only_05_hour' and not is_05 and not enforce:
                 return False
         if project.need_coin:
             if self.config.Research_UseCoin == 'do_not_use':
                 return False
-            if self.config.Research_UseCoin == 'only_05_hour' and not is_05:
+            if self.config.Research_UseCoin == 'only_no_project' and not enforce:
+                return False
+            if self.config.Research_UseCoin == 'only_05_hour' and not is_05 and not enforce:
                 return False
         if project.need_part:
             if self.config.Research_UsePart == 'do_not_use':
                 return False
-            if self.config.Research_UsePart == 'only_05_hour' and not is_05:
+            if self.config.Research_UsePart == 'only_no_project' and not enforce:
+                return False
+            if self.config.Research_UsePart == 'only_05_hour' and not is_05 and not enforce:
                 return False
 
         # Reasons to ignore B series and E-2:

--- a/module/research/research.py
+++ b/module/research/research.py
@@ -18,6 +18,7 @@ class RewardResearch(ResearchSelector):
     _research_project_offset = 0
     _research_finished_index = 2
     research_project_started = None  # ResearchProject
+    enforce = False
 
     def ensure_research_stable(self):
         self.wait_until_stable(STABLE_CHECKER)
@@ -115,9 +116,9 @@ class RewardResearch(ResearchSelector):
             if isinstance(project, str):
                 # priority example: ['shortest']
                 if project == 'shortest':
-                    self.research_select(self.research_sort_shortest())
+                    self.research_select(self.research_sort_shortest(self.enforce))
                 elif project == 'cheapest':
-                    self.research_select(self.research_sort_cheapest())
+                    self.research_select(self.research_sort_cheapest(self.enforce))
                 else:
                     logger.warning(f'Unknown select method: {project}')
                 return True
@@ -129,6 +130,16 @@ class RewardResearch(ResearchSelector):
                     continue
 
         logger.info('No research project started')
+        if (not self.enforce) \
+                and (self.config.Research_UseCube == 'only_no_project'
+                     or self.config.Research_UseCube == 'only_05_hour'
+                     or self.config.Research_UseCoin == 'only_no_project'
+                     or self.config.Research_UseCoin == 'only_05_hour'
+                     or self.config.Research_UsePart == 'only_no_project'
+                     or self.config.Research_UsePart == 'only_05_hour'):
+            logger.info('Enforce choosing research project')
+            self.enforce = True
+            self.research_select(self.research_sort_filter(self.enforce))
         return True
 
     def research_project_start(self, project, skip_first_screenshot=True):
@@ -250,7 +261,8 @@ class RewardResearch(ResearchSelector):
                     self.device.sleep(1.5)
                     self.device.screenshot()
                     record.add(self.device.image)
-                    self.device.swipe_vector((0, 250), box=ITEMS_3_SWIPE.area, random_range=(-10, -10, 10, 10), padding=0)
+                    self.device.swipe_vector((0, 250), box=ITEMS_3_SWIPE.area, random_range=(-10, -10, 10, 10),
+                                             padding=0)
                     self.device.sleep(2)
                     self.device.screenshot()
                     record.add(self.device.image)


### PR DESCRIPTION
因为缺少样本，这个pr只经过了最初步的测试

如果能做的项目只有reset，shortest或cheapest，则放宽限制重新检查
这并不是完全意义上的“无项目可做”，但是考虑到alas代码之间传参的难度，这是一个非常高效的近似解
如果reset在第一位但是后面还有其他项目则不会触发重新检查，不会带来不必要的收益亏损

New settings have been added so that research will hardly stop because there are no projects to choose from.