### PR TITLE
Fix nc server loopback IP for AVD (fix #1236)

### DIFF
--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import time
 import ipaddress
+import platform
 from functools import wraps
 
 import adbutils
@@ -110,6 +111,7 @@ class Connection:
         self.serial = str(self.config.Emulator_Serial)
         self.serial_check()
         self.detect_device()
+        self.is_avd
 
         # Connect
         self.adb_connect(self.serial)
@@ -275,6 +277,16 @@ class Connection:
         return result
 
     @cached_property
+    def is_avd(self):
+        if get_serial_pair(self.serial)[0] is None:
+            return False
+        if 'ranchu' in self.adb_shell(['getprop', 'ro.hardware']):
+            return True
+        if 'goldfish' in self.adb_shell(['getprop', 'ro.hardware.audio.primary']):
+            return True
+        return False
+
+    @cached_property
     def _nc_server_host_port(self):
         """
         Returns:
@@ -290,8 +302,15 @@ class Connection:
         # For emulators, listen on current host
         if self.serial.startswith('emulator-') or self.serial.startswith('127.0.0.1:'):
             host = socket.gethostbyname(socket.gethostname())
+            if platform.system() == 'Linux' and host == '127.0.1.1':
+                host = '127.0.0.1'
             logger.info(f'Connecting to local emulator, using host {host}')
             port = random_port(self.config.FORWARD_PORT_RANGE)
+
+            # For AVD instance
+            if self.is_avd:
+                return host, port, "10.0.2.2", port
+
             return host, port, host, port
         # For local network devices, listen on the host under the same network as target device
         if re.match(r'\d+\.\d+\.\d+\.\d+:\d+', self.serial):


### PR DESCRIPTION
This PR attempts to fix #1236 
- Add check for AVD and return loopback IP 10.0.2.2
- Force `host = '127.0.0.1'` for docker setup
  - So far `host = socket.gethostbyname(socket.gethostname())` when used on host + local emulator will return `127.0.0.1` regardless
  - With some linux setup, there is `127.0.1.1 hostname` entry in `/etc/hosts` (for loopback to localhost) which will error out `nc` as above command will return `127.0.1.1`
  - Hardcoding `127.0.0.1` for any emulator setup is sensible