### PR TITLE
Fix: Alas webui shutdown caused by datetime error

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -115,7 +115,6 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
 
     def load(self):
         self.data = self.read_file(self.config_name)
-        ConfigTypeChecker.check(self.data)
         self.config_override()
 
         for path, value in self.modified.items():
@@ -169,6 +168,7 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
         """
         pending = []
         waiting = []
+        error = []
         now = datetime.now()
         if AzurLaneConfig.is_hoarding_task:
             now -= self.hoarding
@@ -176,7 +176,9 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
             func = Function(func)
             if not func.enable:
                 continue
-            if func.next_run < now:
+            if not isinstance(func.next_run, datetime):
+                error.append(func)
+            elif func.next_run < now:
                 pending.append(func)
             else:
                 waiting.append(func)
@@ -187,6 +189,8 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
             pending = f.apply(pending, func=lambda x: x.enable)
         if waiting:
             waiting = sorted(waiting, key=operator.attrgetter('next_run'))
+        if error:
+            pending = error + pending
 
         self.pending_task = pending
         self.waiting_task = waiting
@@ -623,34 +627,3 @@ class MultiSetWrapper:
         if not self.in_wrapper:
             self.main.update()
             self.main.auto_update = True
-
-
-class ConfigTypeChecker:
-    checkers = [
-        (['Scheduler', 'NextRun'], datetime),
-        (['Emotion', 'Fleet1Record'], datetime),
-        (['Emotion', 'Fleet2Record'], datetime),
-        (['Exercise', 'OpponentRefreshRecord'], datetime),
-    ]
-
-    @classmethod
-    def check(cls, data):
-        """
-        Args:
-            data (dict): User config.
-
-        Raises:
-            RequestHumanTakeover: If there's invalid setting.
-        """
-        for func, func_data in data.items():
-            for path, typ in cls.checkers:
-                value = deep_get(func_data, keys=path, default=None)
-                if value is None:
-                    continue
-                if not isinstance(value, typ):
-                    logger.critical(f'Task `{func}` has an invalid setting {".".join(path)}="{str(value)}". '
-                                    f'Current type: {type_to_str(value)}, expected type: {type_to_str(typ)}')
-                    logger.critical('Please check your settings')
-                    raise RequestHumanTakeover(
-                        f'Task `{func}` has an invalid setting {".".join(path)}="{str(value)}". '
-                        f'Current type: {type_to_str(value)}, expected type: {type_to_str(typ)}')


### PR DESCRIPTION
我就不信这也能翻车

现在时间格式错误的任务会显示在“队列中”的最上方，
并且在启动调度器的时候报错，
再也不用手动改配置文件了

PS：因为现在报错系统还没做好，就这样将就一下好了，我觉得够用了

![${RJRN@0)7XW6`8A2B~JYDI](https://user-images.githubusercontent.com/48789988/176355376-3fa8657b-ec9c-43d8-9750-af91d9bf826b.png)
