### PR TITLE
Fix handle_in_map_no_enemy_searching interface change

### DIFF
--- a/campaign/event_20201029_cn/campaign_base.py
+++ b/campaign/event_20201029_cn/campaign_base.py
@@ -73,7 +73,7 @@ class CampaignBase(CampaignBase_):
 
         return appear
 
-    def handle_in_map_with_enemy_searching(self):
+    def handle_in_map_with_enemy_searching(self, drop=None):
         if not self.is_in_map():
             return False
 


### PR DESCRIPTION
台服活动激唱的 UNIVERSE 活动报错:
`TypeError: handle_in_map_with_enemy_searching() got an unexpected keyword argument 'drop' `
加上 dummy variable 之后似乎可以正常运行