### PR TITLE
Add: EnemyPriority option to WarArchives and SoS

### DIFF
--- a/campaign/campaign_war_archives/campaign_base.py
+++ b/campaign/campaign_war_archives/campaign_base.py
@@ -20,6 +20,7 @@ WAR_ARCHIVES_SCROLL = Scroll(WAR_ARCHIVES_SCROLL, color=(247, 211, 66), name='WA
 class CampaignBase(CampaignBase_):
     # Helper variable to keep track of whether is the first runthrough
     first_run = True
+    ENEMY_FILTER = '1T > 1L > 1E > 1M > 2T > 2L > 2E > 2M > 3T > 3L > 3E > 3M'
 
     def _get_archives_entrance(self, name):
         """

--- a/config/template.json
+++ b/config/template.json
@@ -1364,6 +1364,9 @@
       "RepairUseSingleThreshold": 0.3,
       "RepairUseMultiThreshold": 0.6,
       "LowHpRetreatThreshold": 0.3
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": "default_mode"
     }
   },
   "WarArchives": {
@@ -1433,6 +1436,9 @@
       "RepairUseSingleThreshold": 0.3,
       "RepairUseMultiThreshold": 0.6,
       "LowHpRetreatThreshold": 0.3
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": "default_mode"
     }
   },
   "OpsiGeneral": {

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -6643,6 +6643,17 @@
         "type": "input",
         "value": 0.3
       }
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": {
+        "type": "select",
+        "value": "default_mode",
+        "option": [
+          "default_mode",
+          "S3_enemy_first",
+          "S1_enemy_first"
+        ]
+      }
     }
   },
   "WarArchives": {
@@ -7004,6 +7015,17 @@
       "LowHpRetreatThreshold": {
         "type": "input",
         "value": 0.3
+      }
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": {
+        "type": "select",
+        "value": "default_mode",
+        "option": [
+          "default_mode",
+          "S3_enemy_first",
+          "S1_enemy_first"
+        ]
       }
     }
   },

--- a/module/config/argument/task.yaml
+++ b/module/config/argument/task.yaml
@@ -217,6 +217,7 @@ Sos:
   - Submarine
   - Emotion
   - HpControl
+  - EnemyPriority
 WarArchives:
   - Scheduler
   - Campaign
@@ -225,6 +226,7 @@ WarArchives:
   - Submarine
   - Emotion
   - HpControl
+  - EnemyPriority
 
 # ==================== Opsi ====================
 


### PR DESCRIPTION
Last time I add EnemyFilter but forget to add the priority option in gui, so i add it this time.

上一次在PR中加入了選敵過濾但卻沒在GUI中新增如主線圖的敵人優先度，這次補齊了