### PR TITLE
Opt: Reuse flagship; Add emotion threshold; Delay if not change

### DIFF
--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -72,6 +72,9 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
         """
         Change flagship and flagship's equipment
         If config.GemsFarming_CommonCV == 'any', only change auxiliary equipment
+
+        Returns:
+            bool: True if flagship changed.
         """
 
         if self.config.GemsFarming_CommonCV == 'any':
@@ -88,7 +91,7 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
 
         self._fleet_detail_enter()
 
-        self.flagship_change_execute()
+        success = self.flagship_change_execute()
 
         if self.config.GemsFarming_FlagshipEquipChange:
             logger.info('Record flagship equipment.')
@@ -98,9 +101,14 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
             self.equipment_take_on(index_list=index_list)
             self.ui_back(page_fleet.check_button)
 
+        return success
+
     def vanguard_change(self):
         """
         Change vanguard and vanguard's equipment
+
+        Returns:
+            bool: True if vanguard changed
         """
         logger.hr('CHANGING VANGUARD.')
         if self.config.GemsFarming_VanguardEquipChange:
@@ -112,7 +120,7 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
 
         self._fleet_detail_enter()
 
-        self.vanguard_change_execute()
+        success = self.vanguard_change_execute()
 
         if self.config.GemsFarming_VanguardEquipChange:
             logger.info('Equip vanguard equipment.')
@@ -121,6 +129,8 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
 
             self.equipment_take_on()
             self.ui_back(page_fleet.check_button)
+        
+        return success
 
     def _ship_change_confirm(self, button):
 
@@ -138,6 +148,7 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
 
         level_grids = CARD_LEVEL_GRIDS
         card_grids = CARD_GRIDS
+        emotion_grids = CARD_EMOTION_GRIDS
         logger.hr('FINDING FLAGSHIP')
 
         if self.config.GemsFarming_CommonCV == 'any':
@@ -148,8 +159,12 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
             level_ocr = LevelOcr(level_grids.buttons,
                                  name='DOCK_LEVEL_OCR', threshold=64)
             list_level = level_ocr.ocr(self.device.image)
-            for button, level in list(zip(card_grids.buttons, list_level))[::-1]:
-                if level == 1:
+            emotion_ocr = Digit(emotion_grids.buttons,
+                                name='DOCK_EMOTION_OCR', threshold=176)
+            list_emotion = emotion_ocr.ocr(self.device.image)
+
+            for button, level, emotion in list(zip(card_grids.buttons, list_level, list_emotion))[::-1]:
+                if 0 < level <= 31 and emotion >= 10:
                     return button
 
             return None
@@ -159,20 +174,28 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
 
             self.dock_sort_method_dsc_set()
 
-            ocr = LevelOcr(level_grids.buttons, name='DOCK_LEVEL_OCR')
-            list_level = ocr.ocr(self.device.image)
+            level_ocr = LevelOcr(level_grids.buttons, name='DOCK_LEVEL_OCR')
+            list_level = level_ocr.ocr(self.device.image)
+            emotion_ocr = Digit(emotion_grids.buttons,
+                                name='DOCK_EMOTION_OCR', threshold=176)
+            list_emotion = emotion_ocr.ocr(self.device.image)
 
-            for button, level in zip(card_grids.buttons, list_level):
-                if level == 1 and template.match(self.image_crop(button), similarity=SIM_VALUE):
+            for button, level, emotion in zip(card_grids.buttons, list_level, list_emotion):
+                if (0 < level <= 31
+                        and emotion >= 10
+                        and template.match(self.image_crop(button), similarity=SIM_VALUE)):
                     return button
 
             logger.info('No specific CV was found, try reversed order.')
             self.dock_sort_method_dsc_set(False)
 
-            list_level = ocr.ocr(self.device.image)
+            list_level = level_ocr.ocr(self.device.image)
+            list_emotion = emotion_ocr.ocr(self.device.image)
 
-            for button, level in zip(card_grids.buttons, list_level):
-                if level == 1 and template.match(self.image_crop(button), similarity=SIM_VALUE):
+            for button, level, emotion in zip(card_grids.buttons, list_level, list_emotion):
+                if (0 < level <= 31
+                        and emotion >= 10
+                        and template.match(self.image_crop(button), similarity=SIM_VALUE)):
                     return button
 
             return None
@@ -202,11 +225,16 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
         #     if level == 100 and emotion == 150:
         #         return button
         if self.config.SERVER in ['cn']:
-            button, _, _ = max(filter(lambda a: a[1] == 100, button_list), key=lambda a: a[2])
+            max_level = 100
+        else:
+            max_level = 70
+
+        button_list = list(filter(lambda a: a[1] == max_level and a[2] >= 10, button_list))
+        if button_list:
+            button, _, _ = max(button_list, key=lambda a: a[2])
             return button
         else:
-            button, _, _ = max(filter(lambda a: a[1] == 70, button_list), key=lambda a: a[2])
-            return button
+            return None
 
     def flagship_change_execute(self):
         """
@@ -302,11 +330,12 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
                     raise e
 
             # End
+            success = True
             if self._trigger_lv32 or self._trigger_emotion:
-                self.flagship_change()
+                success = success and self.flagship_change()
 
                 if self.config.GemsFarming_LowEmotionRetreat:
-                    self.vanguard_change()
+                    success = success and self.vanguard_change()
 
                 self._trigger_lv32 = False
                 self._trigger_emotion = False
@@ -317,6 +346,10 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
                 if self.config.task_switched():
                     self.campaign.ensure_auto_search_exit()
                     self.config.task_stop()
+                # Delay
+                if not success:
+                    self.campaign.ensure_auto_search_exit()
+                    self.config.task_delay(minute=30)
 
                 continue
             else:


### PR DESCRIPTION
目前做了3个部分的优化

1. 调整原有的旗舰等级选择，从1替换到区间[1, 31]以复用被更换下来的旗舰
2. 增加了心情阈值，避免仅出击1战就撤退的情况，提高门票的利用率
3. 当前后排任一个无法更换时，推迟任务，避免无意义的频繁操作