### PR TITLE
feat: Dockerfile for Podman

### DIFF
--- a/deploy/docker/Dockerfile.cn
+++ b/deploy/docker/Dockerfile.cn
@@ -14,13 +14,19 @@ RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zi
 WORKDIR /app
 ENV SOURCE=./
 
+# Add Chinese-friendly mirrors for conda
+RUN conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/bioconda/ && \
+    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/ && \
+    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/ && \
+    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge/
+
 # Install the base conda environment
 ENV PYROOT=/app/pyroot
 RUN mamba create --prefix $PYROOT python==3.7.6 -y
 
 # Install the requirements to the conda environment
 COPY $SOURCE/requirements.txt /app/requirements.txt
-RUN $PYROOT/bin/pip install -r /app/requirements.txt
+RUN $PYROOT/bin/pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r /app/requirements.txt
 
 # Initial download of UIAutomator2 is really slow with appetizer mirror (outside of China), switch to github
 RUN sed -i "s#path = mirror_download(url,#path = cache_download(url,#" $PYROOT/lib/python3.7/site-packages/uiautomator2/init.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,4 @@ services:
         build:
             context: ./deploy/docker/
             dockerfile: ./Dockerfile
+            # dockerfile: ./Dockerfile.cn


### PR DESCRIPTION
Prepare `Dockerfile` for `podman` deployment instead of `docker`

Close #1569, will break docker and docker compose deployment

Co-authored-by: jellllly420 <64725601+jellllly420@users.noreply.github.com>