### PR TITLE
优化了MAA插件的serial检测和自定义基建

### DIFF
--- a/submodule/AlasMaaBridge/module/config/i18n/zh-CN.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/zh-CN.json
@@ -134,7 +134,7 @@
     },
     "Serial": {
       "name": "模拟器 Serial",
-      "help": "模拟器默认 Serial：\n- 蓝叠模拟器 127.0.0.1:5555\n- 夜神模拟器 127.0.0.1:62001\n- 夜神模拟器64位 127.0.0.1:59865\n- MuMu模拟器 127.0.0.1:7555\n- 逍遥模拟器 127.0.0.1:21503\n- 雷电模拟器 emulator-5554 或 127.0.0.1:5555\n如果你有多个模拟器，它们的 Serial 将不是默认的，可以在 console.bat 中执行 `adb devices` 查询"
+      "help": "模拟器默认 Serial：\n- 蓝叠模拟器 127.0.0.1:5555\n- 蓝叠模拟器4 Hyper-v版，填\"bluestacks4-hyperv\"自动连接，多开填\"bluestacks4-hyperv-2\"以此类推\n- 蓝叠模拟器5 Hyper-v版，填\"bluestacks5-hyperv\"自动连接，多开填\"bluestacks5-hyperv-1\"以此类推\n- 夜神模拟器 127.0.0.1:62001\n- 夜神模拟器64位 127.0.0.1:59865\n- MuMu模拟器 127.0.0.1:7555\n- 逍遥模拟器 127.0.0.1:21503\n- 雷电模拟器 emulator-5554 或 127.0.0.1:5555\n如果你有多个模拟器，它们的 Serial 将不是默认的，可以在 console.bat 中执行 `adb devices` 查询"
     },
     "PackageName": {
       "name": "游戏服务器",

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -11,7 +11,7 @@ from typing import Any
 from cached_property import cached_property
 
 from deploy.config import DeployConfig
-from module.base.timer import Timer, future_time
+from module.base.timer import Timer
 from module.config.utils import read_file, deep_get
 from module.device.connection_attr import ConnectionAttr
 from module.exception import RequestHumanTakeover

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -400,7 +400,7 @@ class AssistantHandler:
                 if periods is None:
                     logger.critical('无法找到配置文件中的排班周期，请检查文件是否有效')
                     raise RequestHumanTakeover
-                for period in periods:
+                for j, period in enumerate(periods):
                     start_time = datetime.datetime.combine(
                         datetime.date.today(),
                         datetime.datetime.strptime(period[0], '%H:%M').time()
@@ -412,6 +412,13 @@ class AssistantHandler:
                     now_time = datetime.datetime.now()
                     if start_time <= now_time < end_time:
                         args['plan_index'] = i
+                        # 处理跨天的情形
+                        # 如："period": [["22:00", "23:59"], ["00:00","06:00"]]
+                        if j != len(periods) - 1 and period[1] == '23:59' and periods[j + 1][0] == '00:00':
+                            end_time = datetime.datetime.combine(
+                                datetime.date.today() + datetime.timedelta(days=1),
+                                datetime.datetime.strptime(periods[j + 1][1], '%H:%M').time()
+                            )
                         break
                 if 'plan_index' in args:
                     break

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -13,6 +13,7 @@ from cached_property import cached_property
 from deploy.config import DeployConfig
 from module.base.timer import Timer
 from module.config.utils import read_file, deep_get
+from module.device.connection_attr import ConnectionAttr
 from module.exception import RequestHumanTakeover
 from module.logger import logger
 
@@ -176,9 +177,9 @@ class AssistantHandler:
         serial check
         """
         if self.is_bluestacks4_hyperv:
-            self.serial = self.find_bluestacks4_hyperv(self.serial)
+            self.serial = ConnectionAttr.find_bluestacks4_hyperv(self.serial)
         if self.is_bluestacks5_hyperv:
-            self.serial = self.find_bluestacks5_hyperv(self.serial)
+            self.serial = ConnectionAttr.find_bluestacks5_hyperv(self.serial)
                     
     @cached_property
     def is_bluestacks4_hyperv(self):
@@ -187,85 +188,6 @@ class AssistantHandler:
     @cached_property
     def is_bluestacks5_hyperv(self):
         return "bluestacks5-hyperv" in self.serial
-
-    @staticmethod
-    def find_bluestacks4_hyperv(serial):
-        """
-        Find dynamic serial of BlueStacks4 Hyper-V Beta.
-
-        Args:
-            serial (str): 'bluestacks4-hyperv', 'bluestacks4-hyperv-2' for multi instance, and so on.
-
-        Returns:
-            str: 127.0.0.1:{port}
-        """
-        from winreg import HKEY_LOCAL_MACHINE, OpenKey, QueryValueEx
-
-        logger.info("Use BlueStacks4 Hyper-V Beta")
-        logger.info("Reading Realtime adb port")
-
-        if serial == "bluestacks4-hyperv":
-            folder_name = "Android"
-        else:
-            folder_name = f"Android_{serial[19:]}"
-
-        try:
-            with OpenKey(HKEY_LOCAL_MACHINE,
-                         rf"SOFTWARE\BlueStacks_bgp64_hyperv\Guests\{folder_name}\Config") as key:
-                port = QueryValueEx(key, "BstAdbPort")[0]
-        except FileNotFoundError:
-            logger.error(rf'Unable to find registry HKEY_LOCAL_MACHINE\SOFTWARE\BlueStacks_bgp64_hyperv\Guests\{folder_name}\Config')
-            logger.error('Please confirm that your are using BlueStack 4 hyper-v and not regular BlueStacks 4')
-            logger.error(r'Please check if there is any other emulator instances under '
-                         r'registry HKEY_LOCAL_MACHINE\SOFTWARE\BlueStacks_bgp64_hyperv\Guests')
-            raise RequestHumanTakeover
-        logger.info(f"New adb port: {port}")
-        return f"127.0.0.1:{port}"
-
-    @staticmethod
-    def find_bluestacks5_hyperv(serial):
-        """
-        Find dynamic serial of BlueStacks5 Hyper-V.
-
-        Args:
-            serial (str): 'bluestacks5-hyperv', 'bluestacks5-hyperv-1' for multi instance, and so on.
-
-        Returns:
-            str: 127.0.0.1:{port}
-        """
-        from winreg import HKEY_LOCAL_MACHINE, OpenKey, QueryValueEx
-
-        logger.info("Use BlueStacks5 Hyper-V")
-        logger.info("Reading Realtime adb port")
-
-        if serial == "bluestacks5-hyperv":
-            parameter_name = r"bst\.instance\.Nougat64\.status\.adb_port"
-        else:
-            parameter_name = rf"bst\.instance\.Nougat64_{serial[19:]}\.status.adb_port"
-
-        try:
-            with OpenKey(HKEY_LOCAL_MACHINE, r"SOFTWARE\BlueStacks_nxt") as key:
-                directory = QueryValueEx(key, 'UserDefinedDir')[0]
-        except FileNotFoundError:
-            try:
-                with OpenKey(HKEY_LOCAL_MACHINE, r"SOFTWARE\BlueStacks_nxt_cn") as key:
-                    directory = QueryValueEx(key, 'UserDefinedDir')[0]
-            except FileNotFoundError:
-                logger.error('Unable to find registry HKEY_LOCAL_MACHINE\SOFTWARE\BlueStacks_nxt '
-                             'or HKEY_LOCAL_MACHINE\SOFTWARE\BlueStacks_nxt_cn')
-                logger.error('Please confirm that you are using BlueStacks 5 hyper-v and not regular BlueStacks 5')
-                raise RequestHumanTakeover
-        logger.info(f"Configuration file directory: {directory}")
-
-        with open(os.path.join(directory, 'bluestacks.conf'), encoding='utf-8') as f:
-            content = f.read()
-        port = re.search(rf'{parameter_name}="(\d+)"', content)
-        if port is None:
-            logger.warning(f"Did not match the result: {serial}.")
-            raise RequestHumanTakeover
-        port = port.group(1)
-        logger.info(f"Match to dynamic port: {port}")
-        return f"127.0.0.1:{port}"
 
     def connect(self):
         adb = os.path.abspath(DeployConfig().AdbExecutable)

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -11,7 +11,7 @@ from typing import Any
 from cached_property import cached_property
 
 from deploy.config import DeployConfig
-from module.base.timer import Timer
+from module.base.timer import Timer, future_time
 from module.config.utils import read_file, deep_get
 from module.device.connection_attr import ConnectionAttr
 from module.exception import RequestHumanTakeover
@@ -322,27 +322,35 @@ class AssistantHandler:
                 if periods is None:
                     logger.critical('无法找到配置文件中的排班周期，请检查文件是否有效')
                     raise RequestHumanTakeover
-                for j, period in enumerate(periods):
-                    start_time = datetime.datetime.combine(
-                        datetime.date.today(),
-                        datetime.datetime.strptime(period[0], '%H:%M').time()
-                    )
-                    end_time = datetime.datetime.combine(
-                        datetime.date.today(),
-                        datetime.datetime.strptime(period[1], '%H:%M').time()
-                    )
-                    now_time = datetime.datetime.now()
-                    if start_time <= now_time < end_time:
+                period_index = None
+                now_time = datetime.datetime.now().time()
+                periods_sorted = sorted([
+                    tuple(datetime.time.fromisoformat(x) for x in p)
+                    for p in periods
+                ])
+                for j, period in enumerate(periods_sorted):
+                    # 分别对应三种情况：
+                    # [05:00, 07:00], now_time=06:00
+                    # [20:00, 07:00], now_time=06:00
+                    # [20:00, 07:00], now_time=21:00
+                    if (period[0] <= now_time < period[1] or 
+                        now_time < period[1] < period[0] or 
+                        period[1] < period[0] <= now_time):
+                        period_index = j
                         args['plan_index'] = i
-                        # 处理跨天的情形
-                        # 如："period": [["22:00", "23:59"], ["00:00","06:00"]]
-                        if j != len(periods) - 1 and period[1] == '23:59' and periods[j + 1][0] == '00:00':
-                            end_time = datetime.datetime.combine(
-                                datetime.date.today() + datetime.timedelta(days=1),
-                                datetime.datetime.strptime(periods[j + 1][1], '%H:%M').time()
-                            )
                         break
                 if 'plan_index' in args:
+                    periods_sorted = periods_sorted[period_index:] + periods_sorted[:period_index]
+                    future_time_ = lambda x: future_time(x.isoformat(timespec='minutes'))
+                    # 找到下次换班时间，时间差不大于1分钟视为连续时段
+                    # 如[[22:00, 06:59], [05:00, 08:59], [09:00, 10:59], [13:00, 17:59]]
+                    # 现在是22:00，下次在10:59之后换班即可，中间的06:59和08:59不必换班
+                    end_time = future_time_(periods_sorted[0][1])
+                    for period in periods_sorted[1:]:
+                        start_time = future_time_(period[0])
+                        if start_time - end_time > datetime.timedelta(minutes=1):
+                            break
+                        end_time = max(end_time, future_time_(period[1]))
                     break
 
         self.maa_start('Infrast', args)


### PR DESCRIPTION
两个commit分别针对MAA插件的以下问题：
- 检查serial，如果是蓝叠hyper-v版则自行检测adb端口，这部分代码基本上是从`module/device/connection_attr.py`里复制粘贴的；
- 修改自定义基建部分对时段的处理，如果是跨天的情形则将其下次执行时间延缓到第二天相应时段。