### PR TITLE
Fix: Return None if results cached

### DIFF
--- a/module/retire/scanner.py
+++ b/module/retire/scanner.py
@@ -331,8 +331,9 @@ class ShipScanner(Scanner):
         return candidates
 
     def scan(self, image, cached=False, output=True) -> Union[List, None]:
-        return [ship for ship in super().scan(image, cached, output)
-                if ship.satisfy_limitation(self.limitaion)]
+        ships = super().scan(image, cached, output)
+        if not cached:
+            return [ship for ship in ships if ship.satisfy_limitation(self.limitaion)]
 
     def move(self, vector) -> None:
         """


### PR DESCRIPTION
`super().scan(image, cached, output)` is None if cached=True, which cause error