### PR TITLE
Add: Option to skip SSL verify

### DIFF
--- a/config/deploy.template-AidLux-cn.yaml
+++ b/config/deploy.template-AidLux-cn.yaml
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true

--- a/config/deploy.template-AidLux.yaml
+++ b/config/deploy.template-AidLux.yaml
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true

--- a/config/deploy.template-cn.yaml
+++ b/config/deploy.template-cn.yaml
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true

--- a/config/deploy.template-docker-cn.yaml
+++ b/config/deploy.template-docker-cn.yaml
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true

--- a/config/deploy.template-docker.yaml
+++ b/config/deploy.template-docker.yaml
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true

--- a/config/deploy.template.yaml
+++ b/config/deploy.template.yaml
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -14,13 +14,14 @@ class ConfigModel:
     Repository: str = "https://github.com/LmeSzinc/AzurLaneAutoScript"
     Branch: str = "master"
     GitExecutable: str = "./toolkit/Git/mingw64/bin/git.exe"
-    GitProxy: Optional[bool] = None
+    GitProxy: Optional[str] = None
+    SSLVerify: bool = False
     AutoUpdate: bool = True
     KeepLocalChanges: bool = False
 
     # Python
     PythonExecutable: str = "./toolkit/python.exe"
-    PypiMirror: Optional[bool] = None
+    PypiMirror: Optional[str] = None
     InstallDependencies: bool = True
     RequirementsFile: str = "requirements.txt"
 

--- a/deploy/git.py
+++ b/deploy/git.py
@@ -18,7 +18,10 @@ class GitManager(DeployConfig):
         except FileNotFoundError:
             logger.info(f'File not found: {file}')
 
-    def git_repository_init(self, repo, source='origin', branch='master', proxy='', keep_changes=False):
+    def git_repository_init(
+            self, repo, source='origin', branch='master',
+            proxy='', ssl_verify=True, keep_changes=False
+    ):
         logger.hr('Git Init', 1)
         if not self.execute(f'"{self.git}" init', allow_failure=True):
             self.remove('./.git/config')
@@ -33,6 +36,11 @@ class GitManager(DeployConfig):
         else:
             self.execute(f'"{self.git}" config --local --unset http.proxy', allow_failure=True)
             self.execute(f'"{self.git}" config --local --unset https.proxy', allow_failure=True)
+
+        if ssl_verify:
+            self.execute(f'"{self.git}" config --local http.sslVerify true')
+        else:
+            self.execute(f'"{self.git}" config --local http.sslVerify false')
 
         logger.hr('Set Git Repository', 1)
         if not self.execute(f'"{self.git}" remote set-url {source} {repo}', allow_failure=True):
@@ -78,5 +86,6 @@ class GitManager(DeployConfig):
             source='origin',
             branch=self.Branch,
             proxy=self.GitProxy,
+            ssl_verify=self.SSLVerify,
             keep_changes=self.KeepLocalChanges,
         )

--- a/deploy/pip.py
+++ b/deploy/pip.py
@@ -35,9 +35,12 @@ class PipManager(DeployConfig):
         if self.PypiMirror:
             mirror = self.PypiMirror
             arg += ['-i', mirror]
-            # Trust http mirror
-            if 'http:' in mirror:
+            # Trust http mirror or skip ssl verify
+            if 'http:' in mirror or not self.SSLVerify:
                 arg += ['--trusted-host', urlparse(mirror).hostname]
+        elif not self.SSLVerify:
+            arg += ['--trusted-host', 'pypi.org']
+            arg += ['--trusted-host', 'files.pythonhosted.org']
 
         # Don't update pip, just leave it.
         # logger.hr('Update pip', 1)

--- a/deploy/template
+++ b/deploy/template
@@ -16,6 +16,10 @@ Deploy:
     # [CN user] Use your local http proxy (http://127.0.0.1:{port}) or socks5 proxy (socks5://127.0.0.1:{port})
     # [Other] Use null
     GitProxy: null
+    # Set SSL Verify
+    # [In most cases] Use true
+    # [Other] Use false to when connected to an untrusted network
+    SSLVerify: true
     # Update Alas at startup
     # [In most cases] Use true
     AutoUpdate: true


### PR DESCRIPTION
增加了一个SSLVerify的选项，
使得在不安全网络环境下的用户（比如校园网或者野鸡代理），
可以通过牺牲自己本来就不存在的安全性，
绕过SSL证书更新Alas

由于会对其他用户的网络安全造成影响所以做成了选项

PS：这个可能需要打包成release