### PR TITLE
Fix: Error 10054 when install uiautomator2

### DIFF
--- a/deploy/adb.py
+++ b/deploy/adb.py
@@ -37,7 +37,7 @@ class AdbManager(DeployConfig):
             logger.hr('Uiautomator2 Init', 1)
             try:
                 import adbutils
-                from uiautomator2.init import Initer
+                from uiautomator2 import init
             except ModuleNotFoundError as e:
                 message = str(e)
                 for module in ['apkutils2', 'progress']:
@@ -54,14 +54,20 @@ class AdbManager(DeployConfig):
                     del os.environ[k]
 
             for device in adbutils.adb.iter_device():
-                init = Initer(device, loglevel=logging.DEBUG)
-                init.set_atx_agent_addr('127.0.0.1:7912')
-                try:
-                    init.install()
-                except AssertionError:
-                    logger.info(f'AssertionError when installing uiautomator2 on device {device.serial}')
-                    logger.info('If you are using BlueStacks or LD player or WSA, '
-                          'please enable ADB in the settings of your emulator')
-                    exit(1)
-                init._device.shell(["rm", "/data/local/tmp/minicap"])
-                init._device.shell(["rm", "/data/local/tmp/minicap.so"])
+                initer = init.Initer(device, loglevel=logging.DEBUG)
+                initer.set_atx_agent_addr('127.0.0.1:7912')
+
+                for _ in range(2):
+                    try:
+                        initer.install()
+                        break
+                    except AssertionError:
+                        logger.info(f'AssertionError when installing uiautomator2 on device {device.serial}')
+                        logger.info('If you are using BlueStacks or LD player or WSA, '
+                                    'please enable ADB in the settings of your emulator')
+                        exit(1)
+                    except ConnectionError:
+                        init.GITHUB_BASEURL = 'http://tool.appetizer.io/openatx'
+
+                initer._device.shell(["rm", "/data/local/tmp/minicap"])
+                initer._device.shell(["rm", "/data/local/tmp/minicap.so"])

--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -538,7 +538,11 @@ class Connection(ConnectionAttr):
         logger.info('Install uiautomator2')
         init = u2.init.Initer(self.adb, loglevel=logging.DEBUG)
         init.set_atx_agent_addr('127.0.0.1:7912')
-        init.install()
+        try:
+            init.install()
+        except ConnectionError:
+            u2.init.GITHUB_BASEURL = 'http://tool.appetizer.io/openatx'
+            init.install()
         self.uninstall_minicap()
 
     def uninstall_minicap(self):


### PR DESCRIPTION
尝试修复了部分情况下在安装u2的时候会出现ConnectionError: ('Connection aborted.', ConnectionResetError(10054, '远程主机强迫关闭了一个现有的连接。', None, 10054, None))的问题
问题的原因是连接内置的GitHub镜像失败，然后尝试裸连GitHub也失败，Error的内容跟错误的根本原因关系不大
解决方法是把内置的GitHub镜像退化成http然后再试一次，兼顾了重试和绕过安全连接