### PR TITLE
Fix: OSError when loading MAA

### DIFF
--- a/submodule/AlasMaaBridge/module/handler/asst_backup.py
+++ b/submodule/AlasMaaBridge/module/handler/asst_backup.py
@@ -35,6 +35,10 @@ class Asst:
         if platform.system().lower() == 'windows':
             Asst.__libpath = pathlib.Path(path) / 'MaaCore.dll'
             os.environ["PATH"] += os.pathsep + str(path)
+            try:
+                ctypes.WinDLL(str(pathlib.Path(path) / 'onnxruntime.dll'))
+            except Exception:
+                pass
             Asst.__lib = ctypes.WinDLL(str(Asst.__libpath))
         elif platform.system().lower() == 'darwin':
             Asst.__libpath = pathlib.Path(path) / 'libMaaCore.dylib'

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import json
 import time
 import requests
@@ -28,13 +27,13 @@ class AssistantHandler:
 
     @staticmethod
     def load(path, incremental_path=None):
-        sys.path.append(path)
         try:
             from submodule.AlasMaaBridge.module.handler import asst_backup
             AssistantHandler.Asst = asst_backup.Asst
             AssistantHandler.Message = asst_backup.Message
             AssistantHandler.Asst.load(path, user_dir=path, incremental_path=incremental_path)
-        except:
+        except Exception as e:
+            logger.error(e)
             logger.warning('导入MAA失败，尝试使用原生接口导入')
             asst_module = import_module('.asst', 'Python')
             AssistantHandler.Asst = asst_module.Asst


### PR DESCRIPTION
尝试修复了#1937 （高版本的Windows无法正常调用MAA）
提前加载onnxruntime.dll以避免python从错误的位置加载
本地测试没有问题