### PR TITLE
Fix: Wrong log when delay across task

### DIFF
--- a/module/campaign/os_run.py
+++ b/module/campaign/os_run.py
@@ -62,21 +62,8 @@ class OSCampaignRun(OSMapOperation):
                 self.config.task_delay(minute=150, server_update=True)
 
     def opsi_hazard1_leveling(self):
-        self.config.override(
-            OpsiGeneral_AkashiShopFilter='ActionPoint'
-        )
-        self.config.cross_set(keys='OpsiMeowfficerFarming.Scheduler.Enable', value=True)
-        if self.config.cross_get(
-                keys='OpsiMeowfficerFarming.OpsiMeowfficerFarming.ActionPointPreserve',
-                default=0
-        ) < 1000:
-            self.config.cross_set(
-                keys='OpsiMeowfficerFarming.OpsiMeowfficerFarming.ActionPointPreserve',
-                value=1000
-            )
-
-        self.load_campaign()
         try:
+            self.load_campaign()
             self.campaign.os_hazard1_leveling()
         except ActionPointLimit:
             self.config.task_delay(server_update=True)

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -408,9 +408,9 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
                 },
                 allow_none=False,
             )
-            logger.info(f"Delay task `{self.task.command}` to {run} ({kv})")
             if task is None:
                 task = self.task.command
+            logger.info(f"Delay task `{task}` to {run} ({kv})")
             self.modified[f'{task}.Scheduler.NextRun'] = run
             self.update()
         else:

--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -278,6 +278,9 @@ class OperationSiren(OSMap):
         Recommend 3 or 5 for higher meowfficer searching point per action points ratio.
         """
         logger.hr(f'OS meowfficer farming, hazard_level={self.config.OpsiMeowfficerFarming_HazardLevel}', level=1)
+        if self.is_cl1_enabled and self.config.OpsiMeowfficerFarming_ActionPointPreserve < 1000:
+            logger.info('With CL1 leveling enabled, set action point preserve to 1000')
+            self.config.OpsiMeowfficerFarming_ActionPointPreserve = 1000
         preserve = min(self.get_action_point_limit(), self.config.OpsiMeowfficerFarming_ActionPointPreserve, 2000)
         if preserve == 0:
             self.config.override(OpsiFleet_Submarine=False)
@@ -336,6 +339,9 @@ class OperationSiren(OSMap):
 
     def os_hazard1_leveling(self):
         logger.hr('OS hazard 1 leveling', level=1)
+        self.config.override(OpsiGeneral_AkashiShopFilter='ActionPoint')
+        if not self.config.cross_get(keys='OpsiMeowfficerFarming.Scheduler.Enable', default=False):
+            self.config.cross_set(keys='OpsiMeowfficerFarming.Scheduler.Enable', value=True)
         while 1:
             # Limited action point preserve of hazard 1 to 200
             self.config.OS_ACTION_POINT_PRESERVE = 200


### PR DESCRIPTION
修复了跨任务进行延迟任务时log中显示的任务名错误的问题