### PR TITLE
Fix: Keep 1000 AP only when CL1 available but not enabled

### DIFF
--- a/module/config/config_manual.py
+++ b/module/config/config_manual.py
@@ -290,6 +290,7 @@ class ManualConfig:
     """
     OS_ACTION_POINT_BOX_USE = True
     OS_ACTION_POINT_PRESERVE = 0
+    OS_CL1_YELLOW_COINS_PRESERVE = 100000
 
     """
     module.os.globe_detection

--- a/module/os/map.py
+++ b/module/os/map.py
@@ -466,8 +466,9 @@ class OSMap(OSFleet, Map, GlobeCamera, StrategicSearchHandler):
         """
         Keeping enough startup AP to run CL1.
         """
-        if self.is_cl1_enabled and get_os_reset_remain() > 2:
-            logger.info('Keep 1000 AP when CL1 enabled')
+        if self.is_cl1_enabled and get_os_reset_remain() > 2 \
+                and self.get_yellow_coins() > self.config.OS_CL1_YELLOW_COINS_PRESERVE:
+            logger.info('Keep 1000 AP when CL1 available')
             if not self.action_point_check(1000):
                 self.config.opsi_task_delay(cl1_preserve=True)
                 self.config.task_stop()

--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -18,14 +18,13 @@ from module.shop.shop_voucher import VoucherShop
 
 
 class OperationSiren(OSMap):
-    def os_port_daily(self, mission=True, supply=True):
+    def os_port_daily(self, supply=True):
         """
         Accept all missions and buy all supplies in all ports.
         If reach the maximum number of missions, skip accept missions in next port.
         If not having enough yellow coins or purple coins, skip buying supplies in next port.
 
         Args:
-            mission (bool): If needs to accept missions.
             supply (bool): If needs to buy supplies.
 
         Returns:
@@ -263,7 +262,7 @@ class OperationSiren(OSMap):
             self.handle_after_auto_search()
 
     def os_shop(self):
-        self.os_port_daily(mission=False, supply=self.config.OpsiShop_BuySupply)
+        self.os_port_daily(supply=self.config.OpsiShop_BuySupply)
         self.config.task_delay(server_update=True)
 
     def _os_voucher_enter(self):

--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -382,8 +382,8 @@ class OperationSiren(OSMap):
                 self.config.OS_ACTION_POINT_PRESERVE = 0
             logger.attr('OS_ACTION_POINT_PRESERVE', self.config.OS_ACTION_POINT_PRESERVE)
 
-            if self.get_yellow_coins() < 100000:
-                logger.info('Reach the limit of yellow coins, preserve=100000')
+            if self.get_yellow_coins() < self.config.OS_CL1_YELLOW_COINS_PRESERVE:
+                logger.info(f'Reach the limit of yellow coins, preserve={self.config.OS_CL1_YELLOW_COINS_PRESERVE}')
                 with self.config.multi_set():
                     self.config.task_delay(server_update=True)
                     if not self.is_in_opsi_explore():


### PR DESCRIPTION
允许启用侵蚀1功能但黄币不足的时候运行其他大世界任务，
避免黄币不足和侵蚀1失败的情况下坐标堆积的问题