### PR TITLE
Opt: Add optional MAA installation for Docker

### DIFF
--- a/deploy/docker/Docker-run.sh
+++ b/deploy/docker/Docker-run.sh
@@ -51,4 +51,8 @@ prun_or_continue "adb kill-server"
 
 pprint "Running the container"
 trap "rm ${XDG_RUNTIME_DIR}/${CONTAINER}.lock && docker kill ${CONTAINER}" EXIT
+
 prun "docker run --net=host --volume=${SOURCE}/..:/app/AzurLaneAutoScript:rw --interactive --tty --name ${CONTAINER} ${CONTAINER}"
+# If you need MAA support, uncomment the following two lines and comment the line above(Modify the path of MAA according to the actual situation)
+# MAA_SOURCE="${SOURCE}/../../MAA"
+# prun "docker run --net=host --volume=${SOURCE}/..:/app/AzurLaneAutoScript:rw --vloume=${MAA_SOURCE}:/app/MAA:rw --interactive --tty --name ${CONTAINER} ${CONTAINER}"

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,8 +1,23 @@
-FROM condaforge/mambaforge:4.12.0-0
+FROM ubuntu:jammy
+
+ENV CONDA_DIR=/opt/conda
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH=${CONDA_DIR}/bin:${PATH}
 
 # Install dependencies
 RUN apt update && \
-    apt install -y netcat unzip
+    apt install -y netcat unzip wget
+
+# Install mambaforge
+RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
+    bash Mambaforge-Linux-x86_64.sh -b -p ${CONDA_DIR} && \
+    rm Mambaforge-Linux-x86_64.sh && \
+    conda clean --tarballs --index-cache --packages --yes && \
+    find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
+    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
+    conda clean --force-pkgs-dirs --all --yes  && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc && \
+    . ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base
 
 # Install latest adb (41)
 RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zip && \
@@ -11,6 +26,7 @@ RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zi
     ln -s /platform-tools/adb /usr/bin/adb
 
 # Set remote and local dirs
+RUN mkdir /app
 WORKDIR /app
 ENV SOURCE=./
 

--- a/deploy/docker/Dockerfile.cn
+++ b/deploy/docker/Dockerfile.cn
@@ -1,8 +1,23 @@
-FROM condaforge/mambaforge:4.12.0-0
+FROM ubuntu:jammy
+
+ENV CONDA_DIR=/opt/conda
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH=${CONDA_DIR}/bin:${PATH}
 
 # Install dependencies
 RUN apt update && \
-    apt install -y netcat unzip
+    apt install -y netcat unzip wget
+
+# Install mambaforge
+RUN wget https://ghproxy.com/https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
+    bash Mambaforge-Linux-x86_64.sh -b -p ${CONDA_DIR} && \
+    rm Mambaforge-Linux-x86_64.sh && \
+    conda clean --tarballs --index-cache --packages --yes && \
+    find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
+    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
+    conda clean --force-pkgs-dirs --all --yes  && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc && \
+    . ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base
 
 # Install latest adb (41)
 RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zip && \
@@ -11,6 +26,7 @@ RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zi
     ln -s /platform-tools/adb /usr/bin/adb
 
 # Set remote and local dirs
+RUN mkdir /app
 WORKDIR /app
 ENV SOURCE=./
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
         network_mode: host
         volumes:
             - '.:/app/AzurLaneAutoScript:rw'
+            # - '../MAA:/app/MAA:rw'
             - '/etc/localtime:/etc/localtime:ro'
         container_name: 'alas'
         image: 'alas'


### PR DESCRIPTION
Try to add MAA support when building alas docker image

Users should download and extract MAA latest release archive to a specific path(`../MAA`), and then uncomment `# - '../MAA:/app/MAA'` in `docker-compose.yml`, and now they can build a new alas image with MAA support.
In addition, they need to change the `MaaEmulator.MaaPath.name` to `/app/MAA` in MAA configuration.

Tip. Since the MAA latest release is built by g++12 and requires GLIBC 2.32 or higher, we changed the base docker image to ubuntu jammy(22.04 LTS), which already have prebuilt GLIBC 2.35