### PR TITLE
Fix: OpsiMonthBoss is running before OpsiExplore finishes

### DIFF
--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -769,8 +769,12 @@ class OperationSiren(OSMap):
             ActionPointLimit
             TaskEnd: if no more month boss
         """
-        logger.hr("OS clear Month Boss", level=1)
+        if self.is_in_opsi_explore():
+            logger.info('OpsiExplore is under scheduling, stop OpsiMonthBoss')
+            self.config.task_delay(server_update=True)
+            self.config.task_stop()
 
+        logger.hr("OS clear Month Boss", level=1)
         logger.hr("Month Boss precheck", level=2)
         self.os_mission_enter()
         logger.attr('OpsiMonthBoss.Mode', self.config.OpsiMonthBoss_Mode)


### PR DESCRIPTION
Same issue as with OpsiArchive, because both don't require AP to run