### PR TITLE
Opt: Extremely reduce image size built by Dockerfile (-59%)

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,46 +1,18 @@
-FROM ubuntu:jammy
+# docker build -t hgjazhgj/alas:latest .
+# docker run -v ${PWD}:/app/AzurLaneAutoScript -p 22267:22267 --name alas -it --rm hgjazhgj/alas
 
-ENV CONDA_DIR=/opt/conda
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-ENV PATH=${CONDA_DIR}/bin:${PATH}
+FROM python:3.7-slim
 
-# Install dependencies
-RUN apt update && \
-    apt install --no-install-recommends -y netcat unzip wget bzip2 ca-certificates git tini
+WORKDIR /app/AzurLaneAutoScript
 
-# Install mambaforge
-RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
-    bash Mambaforge-Linux-x86_64.sh -b -p ${CONDA_DIR} && \
-    rm Mambaforge-Linux-x86_64.sh && \
-    conda clean --tarballs --index-cache --packages --yes && \
-    find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
-    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
-    conda clean --force-pkgs-dirs --all --yes  && \
-    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc && \
-    . ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base
+COPY requirements.txt /tmp/requirements.txt
 
-# Install latest adb (41)
-RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zip && \
-    unzip platform-tools-latest-linux.zip && \
-    rm platform-tools-latest-linux.zip && \
-    ln -s /platform-tools/adb /usr/bin/adb
+# Initial download of UiAutomator2 is slow outside of China using appetizer mirror, switch to GitHub
+RUN apt update \
+ && apt install -y git adb netcat libgomp1 \
+ && pip install -r /tmp/requirements.txt \
+ && sed -i "s#path = mirror_download(url,#path = cache_download(url,#" /usr/local/lib/python3.7/site-packages/uiautomator2/init.py \
+ && rm /tmp/requirements.txt \
+ && rm -r ~/.cache/pip
 
-# Set remote and local dirs
-RUN mkdir /app
-WORKDIR /app
-ENV SOURCE=./
-
-# Install the base conda environment
-ENV PYROOT=/app/pyroot
-RUN mamba create --prefix $PYROOT python==3.7.6 -y
-
-# Install the requirements to the conda environment
-COPY $SOURCE/requirements.txt /app/requirements.txt
-RUN $PYROOT/bin/pip install -r /app/requirements.txt
-
-# Initial download of UIAutomator2 is really slow with appetizer mirror (outside of China), switch to github
-RUN sed -i "s#path = mirror_download(url,#path = cache_download(url,#" $PYROOT/lib/python3.7/site-packages/uiautomator2/init.py
-
-# When running the image, mount the ALAS folder into the container
-CMD $PYROOT/bin/python -m uiautomator2 init && \
-    $PYROOT/bin/python /app/AzurLaneAutoScript/gui.py
+CMD python gui.py

--- a/deploy/docker/Dockerfile.cn
+++ b/deploy/docker/Dockerfile.cn
@@ -1,52 +1,30 @@
-FROM ubuntu:jammy
+# docker build -t hgjazhgj/alas:latest .
+# docker run -v ${PWD}:/app/AzurLaneAutoScript -p 22267:22267 --name alas -it --rm hgjazhgj/alas
 
-ENV CONDA_DIR=/opt/conda
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-ENV PATH=${CONDA_DIR}/bin:${PATH}
+FROM python:3.7-slim
 
-# Install dependencies
-RUN apt update && \
-    apt install --no-install-recommends -y netcat unzip wget bzip2 ca-certificates git tini
+WORKDIR /app/AzurLaneAutoScript
 
-# Install mambaforge
-RUN wget https://ghproxy.com/https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
-    bash Mambaforge-Linux-x86_64.sh -b -p ${CONDA_DIR} && \
-    rm Mambaforge-Linux-x86_64.sh && \
-    conda clean --tarballs --index-cache --packages --yes && \
-    find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
-    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
-    conda clean --force-pkgs-dirs --all --yes  && \
-    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc && \
-    . ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base
+COPY requirements.txt /tmp/requirements.txt
 
-# Install latest adb (41)
-RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zip && \
-    unzip platform-tools-latest-linux.zip && \
-    rm platform-tools-latest-linux.zip && \
-    ln -s /platform-tools/adb /usr/bin/adb
+# python:3.7-slim is based on debian:11, apt source from https://developer.aliyun.com/mirror/debian
+RUN echo "\
+deb https://mirrors.aliyun.com/debian/ bullseye main non-free contrib\n\
+deb-src https://mirrors.aliyun.com/debian/ bullseye main non-free contrib\n\
+deb https://mirrors.aliyun.com/debian-security/ bullseye-security main\n\
+deb-src https://mirrors.aliyun.com/debian-security/ bullseye-security main\n\
+deb https://mirrors.aliyun.com/debian/ bullseye-updates main non-free contrib\n\
+deb-src https://mirrors.aliyun.com/debian/ bullseye-updates main non-free contrib\n\
+deb https://mirrors.aliyun.com/debian/ bullseye-backports main non-free contrib\n\
+deb-src https://mirrors.aliyun.com/debian/ bullseye-backports main non-free contrib" \
+> /etc/apt/sources.list \
+ && apt update \
+ && apt install -y git adb netcat libgomp1 \
+ && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+ && echo 'Asia/Shanghai' > /etc/timezone \
+ && pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+ && pip install -r /tmp/requirements.txt \
+ && rm /tmp/requirements.txt \
+ && rm -r ~/.cache/pip
 
-# Set remote and local dirs
-RUN mkdir /app
-WORKDIR /app
-ENV SOURCE=./
-
-# Add Chinese-friendly mirrors for conda
-RUN conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/bioconda/ && \
-    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/ && \
-    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/ && \
-    conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge/
-
-# Install the base conda environment
-ENV PYROOT=/app/pyroot
-RUN mamba create --prefix $PYROOT python==3.7.6 -y
-
-# Install the requirements to the conda environment
-COPY $SOURCE/requirements.txt /app/requirements.txt
-RUN $PYROOT/bin/pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r /app/requirements.txt
-
-# Initial download of UIAutomator2 is really slow with appetizer mirror (outside of China), switch to github
-RUN sed -i "s#path = mirror_download(url,#path = cache_download(url,#" $PYROOT/lib/python3.7/site-packages/uiautomator2/init.py
-
-# When running the image, mount the ALAS folder into the container
-CMD $PYROOT/bin/python -m uiautomator2 init && \
-    $PYROOT/bin/python /app/AzurLaneAutoScript/gui.py
+CMD python gui.py


### PR DESCRIPTION
This is the Dockerfile I have used in Docker Desktop with Hyper-V backend, Win 10.  
See [https://github.com/hgjazhgj/Alas_Docker_BlueStacks5](https://github.com/hgjazhgj/Alas_Docker_BlueStacks5).  
![image](https://user-images.githubusercontent.com/40085173/217955374-ddbcafb8-f1ec-4df4-ae6c-40b6a8371e6d.png)
The image size is reduced from 2.44GB to 1GB.  
I am not sure how to do for Dockerfile.cn, it seems that the origin Dockerfile will download some files from GitHub..., and apt sources are not changed.  
I also have Dockerfile for AArch64, running in my RaspberryPi, but using 3rd party MXNet from [https://www.binss.me/blog/run-azurlaneautoscript-on-arm64/](https://www.binss.me/blog/run-azurlaneautoscript-on-arm64/), dose it have the chance to merge into Alas?  