### PR TITLE
Fix: Fix update stuck issue

### DIFF
--- a/deploy/git.py
+++ b/deploy/git.py
@@ -72,7 +72,7 @@ class GitManager(DeployConfig):
             self.execute(f'"{self.git}" pull --ff-only {source} {branch}')
 
         logger.hr('Show Version', 1)
-        self.execute(f'"{self.git}" log --no-merges -1')
+        self.execute(f'"{self.git}" --no-pager log --no-merges -1')
 
     def git_install(self):
         logger.hr('Update Alas', 0)


### PR DESCRIPTION
Fix the problem of getting stuck when entering the interactive interface when the pager prints the update log.

在 Linux 环境下手动安装，在挂机自动更新时，如果 git 配置了 pager，git log --no-merges -1 命令会进入交互界面，需要按 q 退出，导致程序不能自动化，这个补丁通过 --no-pager 参数修复了这个问题