### PR TITLE
Fix lanuch game in no physical keys device

### DIFF
--- a/module/device/method/adb.py
+++ b/module/device/method/adb.py
@@ -242,7 +242,7 @@ class Adb(Connection):
             package_name = self.package
         result = self.adb_shell([
             'monkey', '-p', package_name, '-c',
-            'android.intent.category.LAUNCHER', '1'
+            'android.intent.category.LAUNCHER', '--pct-syskeys', '0', '1'
         ])
         if 'No activities found' in result:
             # ** No activities found to run, monkey aborted.


### PR DESCRIPTION
修复在没有物理按键的设备，比如 X8 沙箱中，无法启动游戏的问题。
由于没有物理按键，monkey 指令会报告： SYS_KEYS has no physical keys but with factor 2.0%
使用 --pct-syskeys 0 参数解决了这一问题，由于本程序使用 monkey 的目的只是启动游戏，增加该参数对其他有物理按键的设备也不会有影响。

在代码中还发现使用  am start 的后备方案对于 android 5.1 的设备也存在问题（并没有在这个 PR 中修复）

代码逻辑中使用正则匹配主 activity 名称，但是 dumpsys 的输出不同版本可能不同，比如安卓 5.1 的输出，无法使用该表达式匹配。

我比对了游戏从 2017 年至今的包，其 main activity 名称没有变化，建议可以固定为：com.manjuu.azurlane.MainActivity，当然可能需要根据区服进行适配。

Fix the problem that the game cannot be launched on devices without physical buttons, such as the X8 sandbox.
Since there are no physical keys, the monkey command will report: SYS_KEYS has no physical keys but with factor 2.0%
Use --pct-syskeys 0 parameter to solve this problem, since the purpose of using monkey in this program is only to start the game, adding and changing the parameter will not affect other devices with physical keys.

In the code, it was also found that the fallback scheme using am start is also problematic for android 5.1 devices (not fixed in this PR)

In the code logic, regular expressions are used to match the main activity name, but the output of dumpsys may be different in different versions, such as the output of Android 5.1, which cannot be matched by this expression.

I compared the package of the game from 2017 to the present, and the name of its main activity has not changed. It is recommended to fix it as: com.manjuu.azurlane.MainActivity. Of course, it may need to be adapted according to the regional server.
