### PR TITLE
Fix: Ocr result of port Taranto in JP server

### DIFF
--- a/module/os/map_operation.py
+++ b/module/os/map_operation.py
@@ -92,6 +92,7 @@ class OSMapOperation(MapOrderHandler, MissionHandler, PortHandler, StorageHandle
         # Katakana 'ペ' may be misread as Hiragana 'ぺ'.
         name = name.replace('一', 'ー').replace('力', 'カ').replace('ぺ', 'ペ')
         name = name.replace('ジブフルタル', 'ジブラルタル')
+        name = name.replace('タント', 'タラント')
         return name
 
     @Config.when(SERVER='tw')


### PR DESCRIPTION
日服大世界港口名ocr识别会将“タラント”识别为“タント”，已仿照直布罗陀港的方式人工修改。