### PR TITLE
Fix: Hazard1Leveling delay should use ap_limit

### DIFF
--- a/module/campaign/os_run.py
+++ b/module/campaign/os_run.py
@@ -66,7 +66,7 @@ class OSCampaignRun(OSMapOperation):
             self.load_campaign()
             self.campaign.os_hazard1_leveling()
         except ActionPointLimit:
-            self.config.task_delay(server_update=True)
+            self.config.task_delay(ap_limit=True)
 
     def opsi_obscure(self):
         try:

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -510,6 +510,7 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
                     "OpsiAbyssal",
                     "OpsiStronghold",
                     "OpsiMeowfficerFarming",
+                    "OpsiHazard1Leveling"
                 ]
             )
             if get_os_reset_remain() > 0:


### PR DESCRIPTION
Resolves #2498 