### PR TITLE
Fix: scanning tower skip should only operate in cl1 zones.

### DIFF
--- a/module/os/map.py
+++ b/module/os/map.py
@@ -758,7 +758,7 @@ class OSMap(OSFleet, Map, GlobeCamera, StrategicSearchHandler):
         if 'is_scanning_device' not in self._solved_map_event and grids and grids[0].is_scanning_device:
             grid = grids[0]
             logger.info(f'Found scanning device on {grid}')
-            if self.is_cl1_enabled:
+            if self.is_cl1_enabled and self.zone.zone_id in [22, 44, 154]:
                 logger.info('CL1 leveling enabled, mark scanning device as solved')
                 self._solved_map_event.add('is_scanning_device')
                 return True

--- a/module/os/map.py
+++ b/module/os/map.py
@@ -758,8 +758,8 @@ class OSMap(OSFleet, Map, GlobeCamera, StrategicSearchHandler):
         if 'is_scanning_device' not in self._solved_map_event and grids and grids[0].is_scanning_device:
             grid = grids[0]
             logger.info(f'Found scanning device on {grid}')
-            if self.is_cl1_enabled and self.zone.zone_id in [22, 44, 154]:
-                logger.info('CL1 leveling enabled, mark scanning device as solved')
+            if self.is_in_task_cl1_leveling:
+                logger.info('In CL1 leveling, mark scanning device as solved')
                 self._solved_map_event.add('is_scanning_device')
                 return True
 


### PR DESCRIPTION
开启侵蚀1后，在短猫侵蚀5碰到探测塔时直接不踩了，这有可能影响海域成就星刷取。