### PR TITLE
Add: Restart game & force stop roguelike (MAA)

### DIFF
--- a/config/template.maa.json
+++ b/config/template.maa.json
@@ -38,6 +38,22 @@
       "Storage": {}
     }
   },
+  "MaaRestart": {
+    "Scheduler": {
+      "Enable": true,
+      "NextRun": "2020-01-01 04:00:00",
+      "Command": "MaaRestart",
+      "SuccessInterval": 0,
+      "FailureInterval": 0,
+      "ServerUpdate": "04:00"
+    },
+    "MaaRestart": {
+      "TimeInterval": 0
+    },
+    "Storage": {
+      "Storage": {}
+    }
+  },
   "MaaAnnihilation": {
     "Scheduler": {
       "Enable": false,
@@ -196,7 +212,7 @@
       "Command": "MaaAward",
       "SuccessInterval": 60,
       "FailureInterval": 120,
-      "ServerUpdate": "04:00, 16:00"
+      "ServerUpdate": "04:00, 16:00, 23:00"
     },
     "Storage": {
       "Storage": {}
@@ -220,7 +236,8 @@
       "Squad": "指挥分队",
       "Roles": "取长补短",
       "CoreChar": null,
-      "Support": "no_use"
+      "Support": "no_use",
+      "RestartGameWhenSwitchNeeded": false
     },
     "Storage": {
       "Storage": {}

--- a/submodule/AlasMaaBridge/maa.py
+++ b/submodule/AlasMaaBridge/maa.py
@@ -114,6 +114,9 @@ class ArknightsAutoScript(AzurLaneAutoScript):
     def maa_startup(self):
         AssistantHandler(config=self.config, asst=self.asst).startup()
 
+    def maa_restart(self):
+        AssistantHandler(config=self.config, asst=self.asst).restart()
+    
     def maa_annihilation(self):
         AssistantHandler(config=self.config, asst=self.asst).fight()
 

--- a/submodule/AlasMaaBridge/module/config/argument/args.json
+++ b/submodule/AlasMaaBridge/module/config/argument/args.json
@@ -124,6 +124,54 @@
       }
     }
   },
+  "MaaRestart": {
+    "Scheduler": {
+      "Enable": {
+        "type": "checkbox",
+        "value": true,
+        "display": "disabled"
+      },
+      "NextRun": {
+        "type": "datetime",
+        "value": "2020-01-01 04:00:00",
+        "validate": "datetime"
+      },
+      "Command": {
+        "type": "input",
+        "value": "MaaRestart",
+        "display": "hide"
+      },
+      "SuccessInterval": {
+        "type": "input",
+        "value": 0,
+        "display": "hide"
+      },
+      "FailureInterval": {
+        "type": "input",
+        "value": 0,
+        "display": "hide"
+      },
+      "ServerUpdate": {
+        "type": "input",
+        "value": "04:00",
+        "display": "hide"
+      }
+    },
+    "MaaRestart": {
+      "TimeInterval": {
+        "type": "input",
+        "value": 0
+      }
+    },
+    "Storage": {
+      "Storage": {
+        "type": "storage",
+        "value": {},
+        "valuetype": "ignore",
+        "display": "disabled"
+      }
+    }
+  },
   "MaaAnnihilation": {
     "Scheduler": {
       "Enable": {
@@ -818,7 +866,7 @@
       },
       "ServerUpdate": {
         "type": "input",
-        "value": "04:00, 16:00",
+        "value": "04:00, 16:00, 23:00",
         "display": "hide"
       }
     },
@@ -933,6 +981,10 @@
           "friend_support",
           "nonfriend_support"
         ]
+      },
+      "RestartGameWhenSwitchNeeded": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Storage": {

--- a/submodule/AlasMaaBridge/module/config/argument/argument.yaml
+++ b/submodule/AlasMaaBridge/module/config/argument/argument.yaml
@@ -54,6 +54,9 @@ MaaRecord:
   ReportToPenguin: false
   PenguinID: null
 
+MaaRestart:
+  TimeInterval: 0
+
 MaaFight:
   Stage:
     value: last
@@ -158,6 +161,7 @@ MaaRoguelike:
   Support:
     value: no_use
     option: [ no_use, friend_support, nonfriend_support ]
+  RestartGameWhenSwitchNeeded: false
 
 # ==================== Tool ====================
 

--- a/submodule/AlasMaaBridge/module/config/argument/default.yaml
+++ b/submodule/AlasMaaBridge/module/config/argument/default.yaml
@@ -7,6 +7,10 @@ MaaStartup:
   Scheduler:
     Enable: true
 
+MaaRestart:
+  Scheduler:
+    Enable: true
+
 MaaMaterial:
   Scheduler:
     FailureInterval: 240

--- a/submodule/AlasMaaBridge/module/config/argument/menu.json
+++ b/submodule/AlasMaaBridge/module/config/argument/menu.json
@@ -3,6 +3,7 @@
     "Maa": [
       "Maa",
       "MaaStartup",
+      "MaaRestart",
       "MaaAnnihilation",
       "MaaMaterial",
       "MaaFight",

--- a/submodule/AlasMaaBridge/module/config/argument/override.yaml
+++ b/submodule/AlasMaaBridge/module/config/argument/override.yaml
@@ -13,6 +13,15 @@ MaaStartup:
     FailureInterval: 0
     ServerUpdate: 04:00
 
+MaaRestart:
+  Scheduler:
+    Enable:
+      value: true
+      display: disabled
+    SuccessInterval: 0
+    FailureInterval: 0
+    ServerUpdate: 04:00
+
 MaaAnnihilation:
   MaaFight:
     Stage: custom
@@ -42,4 +51,4 @@ MaaRecruit:
 
 MaaAward:
   Scheduler:
-    ServerUpdate: 04:00, 16:00
+    ServerUpdate: 04:00, 16:00, 23:00

--- a/submodule/AlasMaaBridge/module/config/argument/task.yaml
+++ b/submodule/AlasMaaBridge/module/config/argument/task.yaml
@@ -14,6 +14,10 @@ Maa:
 MaaStartup:
   - Scheduler
 
+MaaRestart:
+  - Scheduler
+  - MaaRestart
+
 MaaAnnihilation:
   - Scheduler
   - MaaFight

--- a/submodule/AlasMaaBridge/module/config/config.py
+++ b/submodule/AlasMaaBridge/module/config/config.py
@@ -10,7 +10,7 @@ from submodule.AlasMaaBridge.module.config.config_updater import ConfigUpdater
 
 class ArknightsConfig(AzurLaneConfig, ConfigUpdater, GeneratedConfig):
     SCHEDULER_PRIORITY = """
-            MaaStartup
+            MaaStartup > MaaRestart
             > MaaRecruit > MaaInfrast
             > MaaVisit > MaaMall
             > MaaAnnihilation > MaaMaterial

--- a/submodule/AlasMaaBridge/module/config/config_generated.py
+++ b/submodule/AlasMaaBridge/module/config/config_generated.py
@@ -38,6 +38,9 @@ class GeneratedConfig:
     MaaRecord_ReportToPenguin = False
     MaaRecord_PenguinID = None
 
+    # Group `MaaRestart`
+    MaaRestart_TimeInterval = 0
+
     # Group `MaaFight`
     MaaFight_Stage = 'last'  # last, 1-7, LS-6, CA-5, SK-5, AP-5, CE-6, PR-A-1, PR-A-2, PR-B-1, PR-B-2, PR-C-1, PR-C-2, PR-D-1, PR-D-2, custom
     MaaFight_CustomStage = None
@@ -101,6 +104,7 @@ class GeneratedConfig:
     MaaRoguelike_Roles = '取长补短'  # 先手必胜, 稳扎稳打, 取长补短, 随心所欲
     MaaRoguelike_CoreChar = None
     MaaRoguelike_Support = 'no_use'  # no_use, friend_support, nonfriend_support
+    MaaRoguelike_RestartGameWhenSwitchNeeded = False
 
     # Group `MaaCopilot`
     MaaCopilot_FileName = None

--- a/submodule/AlasMaaBridge/module/config/i18n/en-US.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/en-US.json
@@ -22,6 +22,10 @@
       "name": "Task.MaaStartup.name",
       "help": "Task.MaaStartup.help"
     },
+    "MaaRestart": {
+      "name": "Task.MaaRestart.name",
+      "help": "Task.MaaRestart.help"
+    },
     "MaaAnnihilation": {
       "name": "Task.MaaAnnihilation.name",
       "help": "Task.MaaAnnihilation.help"
@@ -174,6 +178,16 @@
     "PenguinID": {
       "name": "MaaRecord.PenguinID.name",
       "help": "MaaRecord.PenguinID.help"
+    }
+  },
+  "MaaRestart": {
+    "_info": {
+      "name": "MaaRestart._info.name",
+      "help": "MaaRestart._info.help"
+    },
+    "TimeInterval": {
+      "name": "MaaRestart.TimeInterval.name",
+      "help": "MaaRestart.TimeInterval.help"
     }
   },
   "MaaFight": {
@@ -534,6 +548,10 @@
       "no_use": "no_use",
       "friend_support": "friend_support",
       "nonfriend_support": "nonfriend_support"
+    },
+    "RestartGameWhenSwitchNeeded": {
+      "name": "MaaRoguelike.RestartGameWhenSwitchNeeded.name",
+      "help": "MaaRoguelike.RestartGameWhenSwitchNeeded.help"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/config/i18n/ja-JP.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/ja-JP.json
@@ -22,6 +22,10 @@
       "name": "Task.MaaStartup.name",
       "help": "Task.MaaStartup.help"
     },
+    "MaaRestart": {
+      "name": "Task.MaaRestart.name",
+      "help": "Task.MaaRestart.help"
+    },
     "MaaAnnihilation": {
       "name": "Task.MaaAnnihilation.name",
       "help": "Task.MaaAnnihilation.help"
@@ -174,6 +178,16 @@
     "PenguinID": {
       "name": "MaaRecord.PenguinID.name",
       "help": "MaaRecord.PenguinID.help"
+    }
+  },
+  "MaaRestart": {
+    "_info": {
+      "name": "MaaRestart._info.name",
+      "help": "MaaRestart._info.help"
+    },
+    "TimeInterval": {
+      "name": "MaaRestart.TimeInterval.name",
+      "help": "MaaRestart.TimeInterval.help"
     }
   },
   "MaaFight": {
@@ -534,6 +548,10 @@
       "no_use": "no_use",
       "friend_support": "friend_support",
       "nonfriend_support": "nonfriend_support"
+    },
+    "RestartGameWhenSwitchNeeded": {
+      "name": "MaaRoguelike.RestartGameWhenSwitchNeeded.name",
+      "help": "MaaRoguelike.RestartGameWhenSwitchNeeded.help"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/config/i18n/zh-CN.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/zh-CN.json
@@ -22,6 +22,10 @@
       "name": "开始唤醒",
       "help": ""
     },
+    "MaaRestart": {
+      "name": "重启游戏",
+      "help": ""
+    },
     "MaaAnnihilation": {
       "name": "剿灭作战",
       "help": ""
@@ -174,6 +178,16 @@
     "PenguinID": {
       "name": "企鹅物流ID",
       "help": "留空即可，第一次上传后会自动生成"
+    }
+  },
+  "MaaRestart": {
+    "_info": {
+      "name": "定时重启",
+      "help": ""
+    },
+    "TimeInterval": {
+      "name": "每隔X分钟定时重启游戏",
+      "help": "特别地，0表示每天4点重启\nX不能大于1440"
     }
   },
   "MaaFight": {
@@ -534,6 +548,10 @@
       "no_use": "不使用",
       "friend_support": "好友助战",
       "nonfriend_support": "好友+非好友助战"
+    },
+    "RestartGameWhenSwitchNeeded": {
+      "name": "切换任务时强制结束肉鸽",
+      "help": "当其它任务需要运行时，立刻重启游戏以强制结束肉鸽\n若不勾选，则当前探索结束才会切换任务"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/config/i18n/zh-TW.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/zh-TW.json
@@ -22,6 +22,10 @@
       "name": "Task.MaaStartup.name",
       "help": "Task.MaaStartup.help"
     },
+    "MaaRestart": {
+      "name": "Task.MaaRestart.name",
+      "help": "Task.MaaRestart.help"
+    },
     "MaaAnnihilation": {
       "name": "Task.MaaAnnihilation.name",
       "help": "Task.MaaAnnihilation.help"
@@ -174,6 +178,16 @@
     "PenguinID": {
       "name": "MaaRecord.PenguinID.name",
       "help": "MaaRecord.PenguinID.help"
+    }
+  },
+  "MaaRestart": {
+    "_info": {
+      "name": "MaaRestart._info.name",
+      "help": "MaaRestart._info.help"
+    },
+    "TimeInterval": {
+      "name": "MaaRestart.TimeInterval.name",
+      "help": "MaaRestart.TimeInterval.help"
     }
   },
   "MaaFight": {
@@ -534,6 +548,10 @@
       "no_use": "no_use",
       "friend_support": "friend_support",
       "nonfriend_support": "nonfriend_support"
+    },
+    "RestartGameWhenSwitchNeeded": {
+      "name": "MaaRoguelike.RestartGameWhenSwitchNeeded.name",
+      "help": "MaaRoguelike.RestartGameWhenSwitchNeeded.help"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -171,6 +171,12 @@ class AssistantHandler:
                 self.params['starts_count'] = 0
                 self.asst.set_task_params(self.task_id, self.params)
                 self.callback_list.remove(self.roguelike_callback)
+                if self.config.MaaRoguelike_RestartGameWhenSwitchNeeded:
+                    # Stop Roguelike
+                    self.asst.stop()
+                    # Restart Game
+                    self.config.task_call('MaaRestart', force_call=True)
+                    return
             else:
                 self.task_switch_timer.reset()
 
@@ -214,6 +220,18 @@ class AssistantHandler:
             "start_game_enabled": True
         })
         self.config.task_delay(server_update=True)
+
+    def restart(self):
+        self.maa_start('CloseDown', {})
+        time.sleep(5)
+        self.maa_start('StartUp', {
+            "client_type": self.config.MaaEmulator_PackageName,
+            "start_game_enabled": True
+        })
+        if self.config.MaaRestart_TimeInterval <= 0 or self.config.MaaRestart_TimeInterval > 24*60:
+            self.config.task_delay(server_update=True)
+        else:
+            self.config.task_delay(minute=self.config.MaaRestart_TimeInterval)
 
     def fight(self):
         args = {


### PR DESCRIPTION
1. 在“自动肉鸽”任务中，增加了“切换任务时强制结束肉鸽”选项。
**功能**：当其它任务需要运行时，立刻重启游戏以强制结束肉鸽（若仅停止任务，不重启游戏，大概率其它任务无法正确识别界面而卡死）。若不开启该功能（即，以前的版本），则当前探索结束才会切换任务。 
**问题**：调用重启时，使用了task_call('MaaRestart', force_call=True)，导致“重启任务”一定会被启动，因此干脆把“重启任务”做成类似“开始唤醒”的常开任务了。是否有更好的方法，能够让“重启任务”仅运行一次？

2. 添加“重启游戏”任务，能够设定“每隔X小时重启游戏”，默认每天04:00执行该任务。
**问题**：“开始唤醒”任务和“重启游戏”任务目前同时存在，不太优雅。