### PR TITLE
Fix OCR for supply line disruption

### DIFF
--- a/module/daily/daily.py
+++ b/module/daily/daily.py
@@ -12,7 +12,7 @@ from module.ui.ui import (BACK_ARROW, page_campaign_menu,
                           page_daily)
 
 DAILY_MISSION_LIST = [DAILY_MISSION_1, DAILY_MISSION_2, DAILY_MISSION_3]
-OCR_REMAIN = Digit(OCR_REMAIN, threshold=128, alphabet='0123')
+OCR_REMAIN = Digit(OCR_REMAIN, threshold=128, alphabet='01234')
 OCR_DAILY_FLEET_INDEX = Digit(OCR_DAILY_FLEET_INDEX, letter=(90, 154, 255), threshold=128, alphabet='123456')
 
 


### PR DESCRIPTION
破交作战改成4次之后，OCR似乎无法正确识别。

修改了一下识别button的大小，破交作战的数字“4”应该可以正确识别了，但是不知道会不会影响其他数字的识别？