### PR TITLE
Fix: Error caused by queue clean status flashback

### DIFF
--- a/module/gacha/gacha_reward.py
+++ b/module/gacha/gacha_reward.py
@@ -197,15 +197,17 @@ class RewardGacha(GachaUI, GeneralShop, Retirement):
         confirm_mode = True  # Drill, Lock Ship
         # Clear button offset, or will click at the PLUS button of gems or HOME button
         STORY_SKIP.clear_offset()
+        queue_clean = True
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
             else:
                 self.device.screenshot()
 
-            if self.appear(BUILD_QUEUE_EMPTY, offset=(20, 20)):
+            if self.appear(BUILD_QUEUE_EMPTY, offset=(20, 20)) and queue_clean:
                 self.gacha_side_navbar_ensure(upper=1)
                 break
+            else: queue_clean = False
             
             if self.appear_then_click(BUILD_FINISH_ORDERS, interval=3):
                 confirm_timer.reset()

--- a/module/gacha/gacha_reward.py
+++ b/module/gacha/gacha_reward.py
@@ -207,7 +207,8 @@ class RewardGacha(GachaUI, GeneralShop, Retirement):
             if self.appear(BUILD_QUEUE_EMPTY, offset=(20, 20)) and queue_clean:
                 self.gacha_side_navbar_ensure(upper=1)
                 break
-            else: queue_clean = False
+            else:
+                queue_clean = False
             
             if self.appear_then_click(BUILD_FINISH_ORDERS, interval=3):
                 confirm_timer.reset()


### PR DESCRIPTION
建造完成时会出现空队列背景干扰循环，该pr加入了状态锁定以免误触空队列条件 #2834