### PR TITLE
remove handle_adb_error for droidcast.py

### DIFF
--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -451,7 +451,7 @@ class Connection(ConnectionAttr):
             port = random_port(self.config.FORWARD_PORT_RANGE)
             forward = ForwardItem(self.serial, f'tcp:{port}', remote)
             logger.info(f'Create forward: {forward}')
-            self.adb.forward(forward.local, forward.remote)
+            self.adb_shell("forward",forward.local, forward.remote)
             return port
 
     def adb_reverse(self, remote):

--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -451,7 +451,7 @@ class Connection(ConnectionAttr):
             port = random_port(self.config.FORWARD_PORT_RANGE)
             forward = ForwardItem(self.serial, f'tcp:{port}', remote)
             logger.info(f'Create forward: {forward}')
-            self.adb_shell("forward",forward.local, forward.remote)
+            self.adb.forward(forward.local, forward.remote)
             return port
 
     def adb_reverse(self, remote):

--- a/module/device/method/droidcast.py
+++ b/module/device/method/droidcast.py
@@ -100,7 +100,14 @@ class DroidCast(Uiautomator2):
     def droidcast_session(self):
         session = requests.Session()
         session.trust_env = False  # Ignore proxy
-        self._droidcast_port = self.adb_forward('tcp:53516')
+        try:
+            # if adb is not found but use adb forward, will expect an AdbError()
+            self._droidcast_port = self.adb_forward('tcp:53516')
+        except AdbError as e:
+            # AdbError()
+            logger.error(e)
+            if not str(e):
+                self.adb_reconnect()
         return session
 
     """

--- a/module/device/method/droidcast.py
+++ b/module/device/method/droidcast.py
@@ -105,6 +105,7 @@ class DroidCast(Uiautomator2):
             self._droidcast_port = self.adb_forward('tcp:53516')
         except AdbError as e:
             # AdbError()
+            logger.error(e)
             if not str(e):
                 self.adb_reconnect()
         return session

--- a/module/device/method/droidcast.py
+++ b/module/device/method/droidcast.py
@@ -100,14 +100,7 @@ class DroidCast(Uiautomator2):
     def droidcast_session(self):
         session = requests.Session()
         session.trust_env = False  # Ignore proxy
-        try:
-            # if adb is not found but use adb forward, will expect an AdbError()
-            self._droidcast_port = self.adb_forward('tcp:53516')
-        except AdbError as e:
-            # AdbError()
-            logger.error(e)
-            if not str(e):
-                self.adb_reconnect()
+        self._droidcast_port = self.adb_forward('tcp:53516')
         return session
 
     """

--- a/module/device/method/droidcast.py
+++ b/module/device/method/droidcast.py
@@ -44,11 +44,10 @@ def retry(func):
                     self.adb_reconnect()
             # AdbError
             except AdbError as e:
-                if handle_adb_error(e):
-                    def init():
-                        self.adb_reconnect()
-                else:
-                    break
+                logger.error(e)
+                
+                def init():
+                    self.adb_reconnect()
             # Package not installed
             except PackageNotInstalled as e:
                 logger.error(e)


### PR DESCRIPTION
类似于#1167，Mac在待机后过一段时间就找不到adb了，需要用adb_reconnect来找
但当使用droidcast作为截图方法的时候，driodcast会直接用本地缓存的数据来create forward，但此时由于adb找不到device，所以会直接报adberror（），然后进去retry，然后由于具体的error为空字符串，这时候AzurLaneAutoScript/module/device/method/utils.py中的handle_adb_error(e)会直接break，但是其实这时候直接adb_reconnect就可以修复，所以我直接把droidcast中的handle_adb_error直接去掉了，这样不管碰到怎么样的adb_error都会尝试进行adb_reconnect。
坏处是这样的话droidcast中的retry_wrapper会和其他地方的retry_wrapper不一样，还有一种方案是直接把AzurLaneAutoScript/module/device/method/utils.py中的handle_adb_error的else改成return true，这样的话也是无论碰到什么adb_error都会尝试adb_reconnect。