### PR TITLE
Fix: tactical failed when the ship's all skills are leveled max

### DIFF
--- a/module/tactical/tactical_class.py
+++ b/module/tactical/tactical_class.py
@@ -624,6 +624,8 @@ class RewardTacticalClass(Dock):
             # Empty skill slot
             # Probably because all favourite ships have their skill leveled max.
             # '———l', '—l'
+            if not level:
+                continue
             if re.search(r'[—\-一]{2,}', level):
                 continue
             if re.search(r'[—一]+', level):


### PR DESCRIPTION
## 问题简述

当只有一个技能的舰娘技能满级时，会出现无法识别的情况，导致Alas一直重复尝试点击一个不存在的技能按钮，最终导致异常停止。

## 复现步骤

1. 确保在战术学院中能选择到的第一只舰娘只有一个技能，且该技能处于满级状态。例如：
![](https://github.com/LmeSzinc/AzurLaneAutoScript/assets/4938213/842c123b-1909-4b00-93a0-64efbd001219)
2. 启动Alas，手动触发技能学习，保证此时战术学院仍有空位。
3. 等待错误出现。

## 日志 && 分析

```text
2023-10-18 21:51:26.040 | INFO | [DOCK_SELECTED 0.013s] 0/1                                                            
2023-10-18 21:51:26.043 | INFO | Click ( 183,  149) @ CARD_0_0                                                         
2023-10-18 21:51:26.265 | INFO | [DOCK_SELECTED 0.008s] 1/1                                                            
2023-10-18 21:51:26.282 | INFO | Click (1004,  669) @ SHIP_CONFIRM                                                     
2023-10-18 21:51:26.863 | INFO | <<< TACTICAL SKILL CHOOSE >>>                                                         
2023-10-18 21:51:26.878 | INFO | Loading OCR model: ./bin/cnocr_models/cnocr                                           
2023-10-18 21:51:26.985 | INFO | [SKILL_LEVEL 0.119s] ['MAX|', '', '————l']                                            
2023-10-18 21:51:26.987 | INFO | [LEVEL] EMPTY                                                                         
2023-10-18 21:51:26.989 | INFO | Tactical skill select                                                                 
2023-10-18 21:51:26.990 | INFO | Click ( 797,  359) @ SKILL_0_1                                                        
2023-10-18 21:51:27.439 | INFO | Click ( 641,  370) @ SKILL_0_1                                                        
2023-10-18 21:51:27.944 | INFO | Click ( 551,  317) @ SKILL_0_1                                                        
2023-10-18 21:51:28.465 | INFO | Click ( 596,  339) @ SKILL_0_1                                                        
2023-10-18 21:51:28.936 | INFO | Click ( 650,  338) @ SKILL_0_1                                                        
2023-10-18 21:51:29.464 | INFO | Click ( 744,  291) @ SKILL_0_1                                                        
2023-10-18 21:51:29.883 | INFO | Click ( 556,  338) @ SKILL_0_1                                                        
2023-10-18 21:51:30.366 | INFO | Click ( 454,  316) @ SKILL_0_1                                                        
2023-10-18 21:51:30.819 | INFO | Click ( 573,  321) @ SKILL_0_1                                                        
2023-10-18 21:51:31.314 | INFO | Click ( 614,  297) @ SKILL_0_1                                                        
2023-10-18 21:51:31.743 | INFO | Click ( 624,  338) @ SKILL_0_1                                                        
2023-10-18 21:51:32.214 | INFO | Click ( 752,  315) @ SKILL_0_1                                                        
2023-10-18 21:51:32.685 | INFO | Click ( 495,  313) @ SKILL_0_1                                                        
2023-10-18 21:51:33.133 | INFO | Click ( 620,  329) @ SKILL_0_1   
```

从日志可以看出，对于不存在的技能按钮，OCR给出了一个空字符串，在后续代码中未对该情况进行处理，导致Alas认为这是一个可以点击的技能按钮，最终导致卡死在该界面。