### PR TITLE
Opt: [ALAS] Add grayscale for matchTemplate

### DIFF
--- a/module/base/template.py
+++ b/module/base/template.py
@@ -114,6 +114,8 @@ class Template(Resource):
 
         if self.is_gif:
             for template in self.image:
+                if template.ndim < image.ndim:
+                    template = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
                 res = cv2.matchTemplate(image, template, cv2.TM_CCOEFF_NORMED)
                 _, sim, _, _ = cv2.minMaxLoc(res)
                 # print(self.file, sim)

--- a/module/base/template.py
+++ b/module/base/template.py
@@ -114,7 +114,7 @@ class Template(Resource):
 
         if self.is_gif:
             for template in self.image:
-                if template.ndim < image.ndim:
+                if template.ndim > image.ndim:
                     template = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
                 res = cv2.matchTemplate(image, template, cv2.TM_CCOEFF_NORMED)
                 _, sim, _, _ = cv2.minMaxLoc(res)


### PR DESCRIPTION
偶然一次发现 ALAS 调用 `matchTemplate` 函数时传入了维度不匹配的两个数组，经调试确认应该是某处对 `image` 做了灰度化处理，建议对 `template` 也做同样的灰度化处理来使传入的参数更规范。

> ~个人的修改十分草率，相信开发者大大会有更好的实现~