### PR TITLE
Fix: ADB connect error

### DIFF
--- a/module/device/connection_attr.py
+++ b/module/device/connection_attr.py
@@ -60,7 +60,7 @@ class ConnectionAttr:
                     continue
                 if 'eri' in k[0].split('_')[-1]:
                     print(k, v)
-                    su.__setattr__(k[0], chr(8) + v)
+                    su.__setattr__(k[0], v)
         # Cache adb_client
         _ = self.adb_client
 


### PR DESCRIPTION
在使用 `127.0.0.1:16416` 连接 MuMu 12 时，产生如下错误：

> 无法连接到 `172.0.0.1` 端口 `16416`，不知道这样的主机 (11001)

通过断点调试，发现实际发送给 ADB 的连接地址为 `\x08127.0.0.1:16416`，为如下代码增加的前缀字符 `\x08`：

https://github.com/LmeSzinc/AzurLaneAutoScript/blob/master/module/device/connection_attr.py#L63C12-L63C12

经测试，删除后恢复正常。