### PR TITLE
Upd: GemsFarming options

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -346,9 +346,12 @@
     },
     "Submarine": {
       "Fleet": 0,
-      "Mode": "hunt_only",
+      "Mode": "do_not_use",
       "AutoSearchMode": "sub_standby",
       "DistanceToBoss": "2_grid_to_boss"
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": "S1_enemy_first"
     },
     "Storage": {
       "Storage": {}

--- a/config/template.json
+++ b/config/template.json
@@ -344,6 +344,12 @@
       "Fleet2Step": 2,
       "FleetOrder": "fleet1_all_fleet2_standby"
     },
+    "Submarine": {
+      "Fleet": 0,
+      "Mode": "hunt_only",
+      "AutoSearchMode": "sub_standby",
+      "DistanceToBoss": "2_grid_to_boss"
+    },
     "Storage": {
       "Storage": {}
     }

--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -72,7 +72,6 @@ class GemsFarming(CampaignRun, Dock, EquipmentChange):
 
         self.campaign = GemsCampaign(device=self.campaign.device, config=self.campaign.config)
         self.campaign.config.override(Emotion_Mode='ignore')
-        self.campaign.config.override(EnemyPriority_EnemyScaleBalanceWeight='S1_enemy_first')
 
     @property
     def change_flagship(self):

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -1681,8 +1681,8 @@
         ],
         "display": "hide",
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -1866,23 +1866,27 @@
         ]
       },
       "Mode": {
-        "type": "state",
-        "value": "hunt_only",
+        "type": "select",
+        "value": "do_not_use",
         "option": [
+          "do_not_use",
           "hunt_only"
         ],
+        "display": "display",
         "option_bold": [
+          "do_not_use",
           "hunt_only"
         ]
       },
       "AutoSearchMode": {
-        "type": "select",
+        "type": "state",
         "value": "sub_standby",
         "option": [
-          "sub_standby",
-          "sub_auto_call"
+          "sub_standby"
         ],
-        "display": "hide"
+        "option_bold": [
+          "sub_standby"
+        ]
       },
       "DistanceToBoss": {
         "type": "select",
@@ -1894,6 +1898,18 @@
           "use_open_ocean_support"
         ],
         "display": "hide"
+      }
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": {
+        "type": "state",
+        "value": "S1_enemy_first",
+        "option": [
+          "S1_enemy_first"
+        ],
+        "option_bold": [
+          "S1_enemy_first"
+        ]
       }
     },
     "Storage": {
@@ -2055,8 +2071,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -2503,8 +2519,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -3896,8 +3912,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -4361,8 +4377,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -4826,8 +4842,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -5291,8 +5307,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -5746,8 +5762,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20210422_cn",
-          "event_20220324_cn"
+          "event_20220324_cn",
+          "event_20210422_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -1681,8 +1681,8 @@
         ],
         "display": "hide",
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -1855,6 +1855,47 @@
         "display": "display"
       }
     },
+    "Submarine": {
+      "Fleet": {
+        "type": "select",
+        "value": 0,
+        "option": [
+          0,
+          1,
+          2
+        ]
+      },
+      "Mode": {
+        "type": "state",
+        "value": "hunt_only",
+        "option": [
+          "hunt_only"
+        ],
+        "option_bold": [
+          "hunt_only"
+        ]
+      },
+      "AutoSearchMode": {
+        "type": "select",
+        "value": "sub_standby",
+        "option": [
+          "sub_standby",
+          "sub_auto_call"
+        ],
+        "display": "hide"
+      },
+      "DistanceToBoss": {
+        "type": "select",
+        "value": "2_grid_to_boss",
+        "option": [
+          "to_boss_position",
+          "1_grid_to_boss",
+          "2_grid_to_boss",
+          "use_open_ocean_support"
+        ],
+        "display": "hide"
+      }
+    },
     "Storage": {
       "Storage": {
         "type": "storage",
@@ -2014,8 +2055,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -2462,8 +2503,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -2872,8 +2913,8 @@
           "raid_20240130"
         ],
         "option_bold": [
-          "raid_20230629",
-          "raid_20240130"
+          "raid_20240130",
+          "raid_20230629"
         ],
         "cn": "raid_20240130",
         "en": "raid_20240130",
@@ -3855,8 +3896,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -4320,8 +4361,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -4785,8 +4826,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -5250,8 +5291,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -5705,8 +5746,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220324_cn",
-          "event_20210422_cn"
+          "event_20210422_cn",
+          "event_20220324_cn"
         ],
         "cn": "event_20220324_cn",
         "en": "event_20220324_cn",
@@ -6112,8 +6153,8 @@
           "raid_20240130"
         ],
         "option_bold": [
-          "raid_20230629",
-          "raid_20240130"
+          "raid_20240130",
+          "raid_20230629"
         ],
         "cn": "raid_20240130",
         "en": "raid_20240130",

--- a/module/config/argument/override.yaml
+++ b/module/config/argument/override.yaml
@@ -48,12 +48,22 @@ GemsFarming:
       option: [ fleet1_all_fleet2_standby, fleet1_standby_fleet2_all ]
   Submarine:
     Mode:
+      display: display
+      value: do_not_use
+      option: [ do_not_use, hunt_only ]
+      option_bold: [ do_not_use, hunt_only ]
+    AutoSearchMode:
       type: state
-      value: hunt_only
-      option: [ hunt_only, ]
-      option_bold: [ hunt_only, ]
-    AutoSearchMode: sub_standby
+      value: sub_standby
+      option: [ sub_standby, ]
+      option_bold: [ sub_standby, ]
     DistanceToBoss: '2_grid_to_boss'
+  EnemyPriority:
+    EnemyScaleBalanceWeight:
+      type: state
+      value: S1_enemy_first
+      option: [ S1_enemy_first, ]
+      option_bold: [ S1_enemy_first, ]
 
 # ==================== Event ====================
 

--- a/module/config/argument/override.yaml
+++ b/module/config/argument/override.yaml
@@ -46,6 +46,14 @@ GemsFarming:
       display: display
       value: fleet1_all_fleet2_standby
       option: [ fleet1_all_fleet2_standby, fleet1_standby_fleet2_all ]
+  Submarine:
+    Mode:
+      type: state
+      value: hunt_only
+      option: [ hunt_only, ]
+      option_bold: [ hunt_only, ]
+    AutoSearchMode: sub_standby
+    DistanceToBoss: '2_grid_to_boss'
 
 # ==================== Event ====================
 

--- a/module/config/argument/task.yaml
+++ b/module/config/argument/task.yaml
@@ -61,6 +61,7 @@ Farm:
       - Campaign
       - StopCondition
       - Fleet
+      - Submarine
 
 # ==================== Event ====================
 

--- a/module/config/argument/task.yaml
+++ b/module/config/argument/task.yaml
@@ -62,6 +62,7 @@ Farm:
       - StopCondition
       - Fleet
       - Submarine
+      - EnemyPriority
 
 # ==================== Event ====================
 

--- a/module/map/map_fleet_preparation.py
+++ b/module/map/map_fleet_preparation.py
@@ -292,6 +292,10 @@ class FleetPreparation(InfoHandler):
             choose=SUBMARINE_CHOOSE, advice=SUBMARINE_ADVICE, bar=SUBMARINE_BAR, clear=SUBMARINE_CLEAR,
             in_use=SUBMARINE_IN_USE, hard_satisfied=SUBMARINE_HARD_SATIESFIED, main=self)
 
+        # Skip submarine setting in auto search
+        if not submarine.allow():
+            self.config.SUBMARINE = 0
+
         # Check if ship is prepared in hard mode
         h1, h2, h3 = fleet_1.is_hard_satisfied(), fleet_2.is_hard_satisfied(), submarine.is_hard_satisfied()
         logger.info(f'Hard satisfied: Fleet_1: {h1}, Fleet_2: {h2}, Submarine: {h3}')
@@ -308,7 +312,7 @@ class FleetPreparation(InfoHandler):
         if self.map_is_hard_mode:
             logger.info('Hard Campaign. No fleet preparation')
             # Clear submarine if user did not set a submarine fleet
-            if submarine.allow():
+            if self.config.SUBMARINE:
                 if self.config.Submarine_Fleet:
                     pass
                 else:


### PR DESCRIPTION
潜艇设置仅允许更改编队和出击方案

关闭自律寻敌时的索敌逻辑不显然，我觉得显示比较好

设置项示意：

![屏幕截图 2024-03-23 211330](https://github.com/LmeSzinc/AzurLaneAutoScript/assets/54128005/b1905615-674b-49f6-a23f-b7c2b4996935)

如果不做，请直接close
