### PR TITLE
Add interactivity check for physical devices with display timeout

### DIFF
--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -747,6 +747,14 @@ class Connection(ConnectionAttr):
         return result
 
     @retry
+    def wake(self):
+        """
+        Attempts to wake device by pressing power button
+        """
+        logger.info('Attempting to wake device')
+        self.adb_shell(['input', 'keyevent', 'KEYCODE_POWER'])
+
+    @retry
     def list_device(self):
         """
         Returns:

--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -720,6 +720,33 @@ class Connection(ConnectionAttr):
         return o
 
     @retry
+    def get_interactive(self):
+        """
+        Makes sure device is interactive before starting tasks
+        """
+        _INTERACTIVE_RE = re.compile(
+            r'mInteractive=(?P<interactive>.+)'
+        )
+        output = self.adb_shell(['dumpsys', 'input_method'])
+
+        interactive = _INTERACTIVE_RE.search(output, 0)
+
+        result = True
+        if interactive:
+            o = interactive.group('interactive')
+            if o == "true":
+                pass
+            elif o == "false":
+                result = False
+            else:
+                logger.warning(f'Invalid device interactivity: {o}, assume it is normal')
+        else:
+            logger.warning('Unable to get device interactivity, assume it is normal')
+
+        logger.attr('Device interactive', {result})
+        return result
+
+    @retry
     def list_device(self):
         """
         Returns:

--- a/module/handler/login.py
+++ b/module/handler/login.py
@@ -34,6 +34,12 @@ class LoginHandler(UI):
         login_success = False
 
         while 1:
+            # Make sure device is interactive
+            if not self.device.get_interactive():
+                self.device.wake()
+                self.device.sleep(1)
+                continue
+
             # Watch device rotation
             if not login_success and orientation_timer.reached():
                 # Screen may rotate after starting an app

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -145,8 +145,7 @@ class UI(InfoHandler):
         timeout = Timer(10, count=20).start()
         while 1:
             if not self.device.get_interactive():
-                logger.info('Device not interactive, attempting to wake device')
-                self.device.adb_shell(['input', 'keyevent', 'KEYCODE_POWER'])
+                self.device.wake()
                 self.device.sleep(1)
                 continue
             if skip_first_screenshot:

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -144,6 +144,11 @@ class UI(InfoHandler):
 
         timeout = Timer(10, count=20).start()
         while 1:
+            if not self.device.get_interactive():
+                logger.info('Device not interactive, attempting to wake device')
+                self.device.adb_shell(['input', 'keyevent', 'KEYCODE_POWER'])
+                self.device.sleep(1)
+                continue
             if skip_first_screenshot:
                 skip_first_screenshot = False
                 if not hasattr(self.device, "image") or self.device.image is None:


### PR DESCRIPTION
Hi there! I recently started running ALAS on a cheap android tablet with a 1 minute display timeout to save energy. I also have it configured to close the game on tasks completion.

However, after ALAS goes to idle and closes the game, it would always fail with logs that look like this and a pure black screenshot:

```
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
                                                      COMMISSION                                                       
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
2024-04-03 15:54:34.291 | INFO | <<< UI ENSURE >>>                                                                     
2024-04-03 15:54:34.308 | INFO | UI get current page                                                                   
2024-04-03 15:54:34.993 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:35.971 | INFO | [Package_name] com.YoStarJP.AzurLane                                                  
2024-04-03 15:54:36.105 | INFO | [Device Orientation] 1 (HOME key on the right)                                        
2024-04-03 15:54:36.952 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:37.836 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:38.706 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:39.587 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:40.545 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:41.446 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:42.350 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:43.239 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:44.123 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:45.011 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:45.901 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:46.838 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:47.730 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:48.598 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:49.485 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:50.374 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:51.264 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:52.136 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:53.058 | INFO | Unknown ui page                                                                       
2024-04-03 15:54:53.876 | WARNING | Unknown ui page                                                                    
2024-04-03 15:54:53.895 | INFO | [EMULATOR__SCREENSHOT_METHOD] ADB_nc                                                  
2024-04-03 15:54:53.910 | INFO | [EMULATOR__CONTROL_METHOD] ADB                                                        
2024-04-03 15:54:53.921 | INFO | [SERVER] jp                                                                           
2024-04-03 15:54:53.932 | WARNING | Starting from current page is not supported                                        
2024-04-03 15:54:53.939 | WARNING | Supported page: ['page_main', 'page_campaign_menu', 'page_campaign', 'page_fleet', 
'page_unknown', 'page_exercise', 'page_daily', 'page_event', 'page_sp', 'page_coalition', 'page_os', 'page_archives',  
'page_reward', 'page_mission', 'page_guild', 'page_commission', 'page_tactical', 'page_battle_pass', 'page_event_list',
'page_raid', 'page_research', 'page_shipyard', 'page_meta', 'page_storage', 'page_reshmenu', 'page_dormmenu',          
'page_dorm', 'page_meowfficer', 'page_academy', 'page_game_room', 'page_shop', 'page_munitions', 'page_supply_pack',   
'page_build', 'page_rpg_stage', 'page_rpg_story', 'page_rpg_city']                                                     
2024-04-03 15:54:53.972 | WARNING | Supported page: Any page with a "HOME" button on the upper-right                   
2024-04-03 15:54:53.983 | CRITICAL | Please switch to a supported page before starting Alas                            
2024-04-03 15:54:53.991 | INFO | Game server may be under maintenance or network may be broken, check server status now
2024-04-03 15:54:54.508 | INFO | Server "キール" is available.                                                         
2024-04-03 15:54:54.530 | CRITICAL | Game page unknown                                                                 
2024-04-03 15:54:54.560 | WARNING | Saving error: ./log/error/1712127294560                                            
```

This seems to be because the device went to sleep, so I added a new function to check for device interactivity (which is set to false when display is off), and used it in the ui_get_current_page and handle_app_login loops to wake the device if not interactive.

I've been running with these changes for the past week and it hasn't required any manual interventions yet. I've defaulted the result of the function to true in the case where we can't find the expected adb outputs to keep behavior identical for older devices and emulators, but I haven't actually tested on an emulator yet since I don't have one set up. Would appreciate some help with this from folks that run ALAS on emulators!

I'm a bit of a python noob, so there might be some mistakes in here. Happy to update this as you see fit. Thanks!