### PR TITLE
Opt: sort latest events in config update

### DIFF
--- a/module/config/config_updater.py
+++ b/module/config/config_updater.py
@@ -435,7 +435,7 @@ class ConfigGenerator:
             latest = {}
             for server in ARCHIVES_PREFIX.keys():
                 latest[server] = deep_pop(self.args, keys=f'{task}.Campaign.Event.{server}', default='')
-            bold = list(set(latest.values()))
+            bold = sorted(set(latest.values()))
             deep_set(self.args, keys=f'{task}.Campaign.Event.option_bold', value=bold)
             for server, event in latest.items():
                 deep_set(self.args, keys=f'{task}.Campaign.Event.{server}', value=event)


### PR DESCRIPTION
`set`是无序的，这导致运行`config_updater.py`可能会无意义地更改`option_bold`，在commit中塞入大量垃圾内容。