### PR TITLE
Add: Custom Emulator && Emulator restart

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -12,7 +12,11 @@
     "EmulatorInfo": {
       "Emulator": "auto",
       "name": null,
-      "path": null
+      "path": null,
+      "CustomStartEmulator": null,
+      "CustomStopEmulator": null,
+      "Timeout": 90,
+      "DailyRestart": false
     },
     "Error": {
       "HandleError": true,
@@ -1865,7 +1869,8 @@
   },
   "GameManager": {
     "GameManager": {
-      "AutoRestart": true
+      "AutoRestart": true,
+      "RestartEmulator": false
     },
     "Storage": {
       "Storage": {}

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -158,7 +158,8 @@
           "MuMuPlayer",
           "MuMuPlayerX",
           "MuMuPlayer12",
-          "MEmuPlayer"
+          "MEmuPlayer",
+          "CustomEmulator"
         ]
       },
       "name": {
@@ -168,6 +169,22 @@
       "path": {
         "type": "textarea",
         "value": null
+      },
+      "CustomStartEmulator": {
+        "type": "textarea",
+        "value": null
+      },
+      "CustomStopEmulator": {
+        "type": "textarea",
+        "value": null
+      },
+      "Timeout": {
+        "type": "input",
+        "value": 90
+      },
+      "DailyRestart": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Error": {
@@ -1702,8 +1719,8 @@
         ],
         "display": "hide",
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -2035,8 +2052,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -2483,8 +2500,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -2894,8 +2911,8 @@
           "raid_20240328"
         ],
         "option_bold": [
-          "raid_20240328",
-          "raid_20230629"
+          "raid_20230629",
+          "raid_20240328"
         ],
         "cn": "raid_20240328",
         "en": "raid_20240328",
@@ -3877,8 +3894,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -4342,8 +4359,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -4807,8 +4824,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -5272,8 +5289,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -5727,8 +5744,8 @@
           "event_20240229_cn"
         ],
         "option_bold": [
-          "event_20220224_cn",
-          "event_20211111_cn"
+          "event_20211111_cn",
+          "event_20220224_cn"
         ],
         "cn": "event_20220224_cn",
         "en": "event_20220224_cn",
@@ -6135,8 +6152,8 @@
           "raid_20240328"
         ],
         "option_bold": [
-          "raid_20240328",
-          "raid_20230629"
+          "raid_20230629",
+          "raid_20240328"
         ],
         "cn": "raid_20240328",
         "en": "raid_20240328",
@@ -9139,6 +9156,10 @@
       "AutoRestart": {
         "type": "checkbox",
         "value": true
+      },
+      "RestartEmulator": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Storage": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -73,6 +73,7 @@ EmulatorInfo:
       MuMuPlayerX,
       MuMuPlayer12,
       MEmuPlayer,
+      CustomEmulator,
     ]
   name:
     value: null
@@ -80,6 +81,14 @@ EmulatorInfo:
   path:
     value: null
     type: textarea
+  CustomStartEmulator:
+    value: null
+    type: textarea
+  CustomStopEmulator:
+    value: null
+    type: textarea
+  Timeout: 90
+  DailyRestart: false
 Error:
   HandleError: true
   SaveError: true
@@ -723,3 +732,4 @@ AzurLaneUncensored:
     display: disabled
 GameManager:
   AutoRestart: true
+  RestartEmulator: false

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -27,9 +27,13 @@ class GeneratedConfig:
     Emulator_AdbRestart = False
 
     # Group `EmulatorInfo`
-    EmulatorInfo_Emulator = 'auto'  # auto, NoxPlayer, NoxPlayer64, BlueStacks4, BlueStacks5, BlueStacks4HyperV, BlueStacks5HyperV, LDPlayer3, LDPlayer4, LDPlayer9, MuMuPlayer, MuMuPlayerX, MuMuPlayer12, MEmuPlayer
+    EmulatorInfo_Emulator = 'auto'  # auto, NoxPlayer, NoxPlayer64, BlueStacks4, BlueStacks5, BlueStacks4HyperV, BlueStacks5HyperV, LDPlayer3, LDPlayer4, LDPlayer9, MuMuPlayer, MuMuPlayerX, MuMuPlayer12, MEmuPlayer, CustomEmulator
     EmulatorInfo_name = None
     EmulatorInfo_path = None
+    EmulatorInfo_CustomStartEmulator = None
+    EmulatorInfo_CustomStopEmulator = None
+    EmulatorInfo_Timeout = 90
+    EmulatorInfo_DailyRestart = False
 
     # Group `Error`
     Error_HandleError = True
@@ -435,6 +439,7 @@ class GeneratedConfig:
 
     # Group `GameManager`
     GameManager_AutoRestart = True
+    GameManager_RestartEmulator = False
 
     # Group `Storage`
     Storage_Storage = {}

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -451,7 +451,8 @@
       "MuMuPlayer": "MuMu Player",
       "MuMuPlayerX": "MuMu Player X",
       "MuMuPlayer12": "MuMu Player 12",
-      "MEmuPlayer": "MEmu Player"
+      "MEmuPlayer": "MEmu Player",
+      "CustomEmulator": "Custom"
     },
     "name": {
       "name": "Emulator Instance Name",
@@ -460,6 +461,22 @@
     "path": {
       "name": "Emulator Installation Path",
       "help": ""
+    },
+    "CustomStartEmulator": {
+      "name": "Custom startup command",
+      "help": "Only takes effect when the option is 'Custom'"
+    },
+    "CustomStopEmulator": {
+      "name": "Custom stop command",
+      "help": "Only takes effect when the option is 'Custom'"
+    },
+    "Timeout": {
+      "name": "Timeout waiting for emulator startup to complete",
+      "help": "Unit: seconds"
+    },
+    "DailyRestart": {
+      "name": "Restart Emulator when Server Refreshes",
+      "help": "Restart emulator every day to solve the memory leak problem"
     }
   },
   "Error": {
@@ -2462,6 +2479,10 @@
     "AutoRestart": {
       "name": "Automatic Login",
       "help": "Log back into the game when the game has been ended."
+    },
+    "RestartEmulator": {
+      "name": "Restart the emulator",
+      "help": ""
     }
   },
   "Storage": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -451,7 +451,8 @@
       "MuMuPlayer": "MuMuPlayer",
       "MuMuPlayerX": "MuMuPlayerX",
       "MuMuPlayer12": "MuMuPlayer12",
-      "MEmuPlayer": "MEmuPlayer"
+      "MEmuPlayer": "MEmuPlayer",
+      "CustomEmulator": "CustomEmulator"
     },
     "name": {
       "name": "EmulatorInfo.name.name",
@@ -460,6 +461,22 @@
     "path": {
       "name": "EmulatorInfo.path.name",
       "help": "EmulatorInfo.path.help"
+    },
+    "CustomStartEmulator": {
+      "name": "EmulatorInfo.CustomStartEmulator.name",
+      "help": "EmulatorInfo.CustomStartEmulator.help"
+    },
+    "CustomStopEmulator": {
+      "name": "EmulatorInfo.CustomStopEmulator.name",
+      "help": "EmulatorInfo.CustomStopEmulator.help"
+    },
+    "Timeout": {
+      "name": "EmulatorInfo.Timeout.name",
+      "help": "EmulatorInfo.Timeout.help"
+    },
+    "DailyRestart": {
+      "name": "EmulatorInfo.DailyRestart.name",
+      "help": "EmulatorInfo.DailyRestart.help"
     }
   },
   "Error": {
@@ -2462,6 +2479,10 @@
     "AutoRestart": {
       "name": "GameManager.AutoRestart.name",
       "help": "GameManager.AutoRestart.help"
+    },
+    "RestartEmulator": {
+      "name": "GameManager.RestartEmulator.name",
+      "help": "GameManager.RestartEmulator.help"
     }
   },
   "Storage": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -451,7 +451,8 @@
       "MuMuPlayer": "MuMu模拟器",
       "MuMuPlayerX": "MuMu模拟器X",
       "MuMuPlayer12": "MuMu模拟器12",
-      "MEmuPlayer": "逍遥模拟器"
+      "MEmuPlayer": "逍遥模拟器",
+      "CustomEmulator": "自定义"
     },
     "name": {
       "name": "模拟器实例名称",
@@ -460,6 +461,22 @@
     "path": {
       "name": "模拟器安装路径",
       "help": ""
+    },
+    "CustomStartEmulator": {
+      "name": "自定义启动指令",
+      "help": "仅当模拟器类型为‘自定义’时生效"
+    },
+    "CustomStopEmulator": {
+      "name": "自定义停止指令",
+      "help": "仅当模拟器类型为‘自定义’时生效"
+    },
+    "Timeout": {
+      "name": "等待模拟器启动完成的超时时间",
+      "help": "单位：秒"
+    },
+    "DailyRestart": {
+      "name": "服务器刷新时重启模拟器",
+      "help": "每天主动重启模拟器以解决内存泄露问题"
     }
   },
   "Error": {
@@ -2462,6 +2479,10 @@
     "AutoRestart": {
       "name": "自动登录",
       "help": "游戏被强制结束后自动登录游戏"
+    },
+    "RestartEmulator": {
+      "name": "重启模拟器",
+      "help": ""
     }
   },
   "Storage": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -451,7 +451,8 @@
       "MuMuPlayer": "MuMu模擬器",
       "MuMuPlayerX": "MuMu模擬器X",
       "MuMuPlayer12": "MuMu模擬器12",
-      "MEmuPlayer": "逍遙模擬器"
+      "MEmuPlayer": "逍遙模擬器",
+      "CustomEmulator": "自訂模擬器"
     },
     "name": {
       "name": "模擬器實例名稱",
@@ -460,6 +461,22 @@
     "path": {
       "name": "模擬器安裝路徑",
       "help": ""
+    },
+    "CustomStartEmulator": {
+      "name": "模擬器啟動指令",
+      "help": "僅當選項為‘自訂模擬器’時生效"
+    },
+    "CustomStopEmulator": {
+      "name": "模擬器停止指令",
+      "help": "僅當選項為‘自訂模擬器’時生效"
+    },
+    "Timeout": {
+      "name": "等待模擬器啟動完成的逾時時間",
+      "help": "單位：秒"
+    },
+    "DailyRestart": {
+      "name": "伺服器重繪時重啟模擬器",
+      "help": "每天主動重啟模擬器以解决記憶體洩漏問題"
     }
   },
   "Error": {
@@ -2462,6 +2479,10 @@
     "AutoRestart": {
       "name": "自動登錄",
       "help": "遊戲被強制結束後自動登錄遊戲"
+    },
+    "RestartEmulator": {
+      "name": "重新啟動模擬器",
+      "help": ""
     }
   },
   "Storage": {

--- a/module/daemon/game_manager.py
+++ b/module/daemon/game_manager.py
@@ -4,9 +4,14 @@ from module.logger import logger
 
 class GameManager(LoginHandler):
     def run(self):
-        logger.hr('Force Stop AzurLane', level=1)
-        self.device.app_stop()
-        logger.info('Force Stop finished')
+        if self.config.GameManager_RestartEmulator:
+            logger.hr('Force Restart Emulator', level=1)
+            self.device.emulator_restart()
+            logger.info('Force Restart finished')
+        else:
+            logger.hr('Force Stop AzurLane', level=1)
+            self.device.app_stop()
+            logger.info('Force Stop finished')
 
         if self.config.GameManager_AutoRestart:
             self.device.app_start()

--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -228,7 +228,7 @@ class Connection(ConnectionAttr):
             # str
             return result
 
-    def adb_getprop(self, name):
+    def adb_getprop(self, name, default_value=None):
         """
         Get system property in Android, same as `getprop <name>`
 
@@ -238,7 +238,10 @@ class Connection(ConnectionAttr):
         Returns:
             str:
         """
-        return self.adb_shell(['getprop', name]).strip()
+        shell_cmd = ['getprop', name]
+        if default_value is not None:
+            shell_cmd.append(default_value)
+        return self.adb_shell(shell_cmd).strip()
 
     @cached_property
     def cpu_abi(self) -> str:

--- a/module/device/platform/__init__.py
+++ b/module/device/platform/__init__.py
@@ -2,5 +2,7 @@ import sys
 
 if sys.platform == 'win32':
     from module.device.platform.platform_windows import PlatformWindows as Platform
+elif sys.platform == 'linux':
+    from module.device.platform.platform_linux import PlatformLinux as Platform
 else:
     from module.device.platform.platform_base import PlatformBase as Platform

--- a/module/device/platform/emulator_base.py
+++ b/module/device/platform/emulator_base.py
@@ -134,6 +134,7 @@ class EmulatorBase:
     MuMuPlayer12 = 'MuMuPlayer12'
     MuMuPlayerFamily = [MuMuPlayer, MuMuPlayerX, MuMuPlayer12]
     MEmuPlayer = 'MEmuPlayer'
+    CustomEmulator = 'CustomEmulator'
 
     @classmethod
     def path_to_type(cls, path: str) -> str:

--- a/module/device/platform/emulator_linux.py
+++ b/module/device/platform/emulator_linux.py
@@ -1,0 +1,18 @@
+from module.device.platform.emulator_base import EmulatorBase, EmulatorInstanceBase, EmulatorManagerBase
+
+
+class EmulatorInstance(EmulatorInstanceBase):
+    pass
+
+
+class Emulator(EmulatorBase):
+    pass
+
+
+class EmulatorManager(EmulatorManagerBase):
+    pass
+
+if __name__ == '__main__':
+    self = EmulatorManager()
+    for emu in self.all_emulator_instances:
+        print(emu)

--- a/module/device/platform/platform_linux.py
+++ b/module/device/platform/platform_linux.py
@@ -1,0 +1,46 @@
+import subprocess
+import sys
+
+from module.device.platform.emulator_base import EmulatorBase
+from module.device.platform.emulator_linux import EmulatorManager
+from module.device.platform.platform_base import PlatformBase
+from module.logger import logger
+
+
+class PlatformLinux(PlatformBase, EmulatorManager):
+
+    def execute(cls, command):
+        """
+        Args:
+            command (str):
+
+        Returns:
+            True/False
+        """
+        command = command.replace(r"\\", "/").replace("\\", "/").replace('"', '"')
+        logger.info(f'Execute: {command}')
+        return subprocess.run(command, shell=True, close_fds=True).returncode == 0
+
+
+    def emulator_start(self):
+        """
+        Start a emulator, until startup completed.
+        - Retry is required.
+        - Using bored sleep to wait startup is forbidden.
+        """
+        if self.emulator_info.emulator != EmulatorBase.CustomEmulator:
+            logger.warning(f'Current platform {sys.platform} does not support emulator_start of {self.emulator_info.emulator}, skip')
+            return
+
+        self.custom_emulator_start()
+
+    def emulator_stop(self):
+        """
+        Stop a emulator.
+        """
+        if self.emulator_info.emulator != EmulatorBase.CustomEmulator:
+            logger.warning(f'Current platform {sys.platform} does not support emulator_stop of {self.emulator_info.emulator}, skip')
+            return
+
+        self.custom_emulator_stop()
+

--- a/module/device/platform/platform_windows.py
+++ b/module/device/platform/platform_windows.py
@@ -43,7 +43,7 @@ def flash_window(hwnd, flash=True):
 
 
 class PlatformWindows(PlatformBase, EmulatorManager):
-    @classmethod
+
     def execute(cls, command):
         """
         Args:
@@ -103,6 +103,8 @@ class PlatformWindows(PlatformBase, EmulatorManager):
         elif instance == Emulator.BlueStacks4:
             # BlueStacks\Client\Bluestacks.exe -vmname Android_1
             self.execute(f'"{exe}" -vmname {instance.name}')
+        elif instance == Emulator.CustomEmulator:
+            self.custom_emulator_start()
         else:
             raise EmulatorUnknown(f'Cannot start an unknown emulator instance: {instance}')
 
@@ -157,6 +159,8 @@ class PlatformWindows(PlatformBase, EmulatorManager):
         elif instance == Emulator.NoxPlayerFamily:
             # Nox.exe -clone:Nox_1 -quit
             self.execute(f'"{exe}" -clone:{instance.name} -quit')
+        elif instance == Emulator.CustomEmulator:
+            self.custom_emulator_stop()
         else:
             raise EmulatorUnknown(f'Cannot stop an unknown emulator instance: {instance}')
 

--- a/module/handler/login.py
+++ b/module/handler/login.py
@@ -155,7 +155,12 @@ class LoginHandler(UI):
 
     def app_restart(self):
         logger.hr('App restart')
-        self.device.app_stop()
+        if self.config.EmulatorInfo_DailyRestart \
+                and self.config.Scheduler_NextRun.strftime('%H:%M:%S') \
+                == get_server_next_update(self.config.Scheduler_ServerUpdate).strftime('%H:%M:%S'):
+            self.device.emulator_restart()
+        else:
+            self.device.app_stop()
         self.device.app_start()
         self.handle_app_login()
         # self.ensure_no_unfinished_campaign()


### PR DESCRIPTION
1. 额外添加 CustomEmulator ，容许用户自定义启动及停止模拟器的指令
2. 恢复选项“服务器刷新时重启模拟器”，每天晚上在alas重启时执行，解决内存泄漏问题
3. 为 游戏管理器 添加 “重启模拟器” 选项（不仅可以远程重启App，也能重启模拟器了）
4. 在adb连接成功的情况下，通过检测 sys.boot_completed 属性值来判断模拟器是否启动完成