### PR TITLE
Fix: equipment image record in fast PC

### DIFF
--- a/module/equipment/equipment_change.py
+++ b/module/equipment/equipment_change.py
@@ -36,7 +36,19 @@ class EquipmentChange(Equipment):
         """
         logger.info('RECORD EQUIPMENT')
         self.ship_side_navbar_ensure(bottom=1)
+
+        # Ensure EQUIPMENT_GRID in the right place
+        skip_first_screenshot = True
+        while True:
+            if skip_first_screenshot:
+                skip_first_screenshot = False
+            else:
+                self.device.screenshot()
+            if self.appear(EQUIPMENT_OPEN):
+                break
+
         self.equipment_list = {}
+        info_bar_disappeared = False
         for index, button in enumerate(EQUIPMENT_GRID.buttons):
             if index not in index_list:
                 continue
@@ -53,11 +65,18 @@ class EquipmentChange(Equipment):
                 # Enter upgrade inform
                 self.ui_click(click_button=UPGRADE_ENTER,
                               check_button=UPGRADE_ENTER_CHECK, skip_first_screenshot=True)
+                # Save equipment template
+                if not info_bar_disappeared:
+                    self.handle_info_bar()
+                    info_bar_disappeared = True
                 self.equipment_list[index] = self.image_crop(EQUIP_SAVE)
                 # Quit upgrade inform
                 self.ui_click(
                     click_button=UPGRADE_QUIT, check_button=EQUIPMENT_OPEN, appear_button=UPGRADE_ENTER_CHECK,
                     skip_first_screenshot=True)
+            else:
+                logger.info(f"Equipment {index} is empty")
+
         logger.info(f"Recorded equipment index list: {list(self.equipment_list.keys())}")
 
     def ship_equipment_take_on_image(self, index_list=range(0, 5), skip_first_screenshot=True):


### PR DESCRIPTION
1. info_bar导致图像裁剪出错
    ![碧蓝航线(3) mp4_20240428_231211 083](https://github.com/LmeSzinc/AzurLaneAutoScript/assets/54128005/c9f0d982-9b18-4b5c-85d0-c30ab1f7f7ac)

2. 动画太慢导致装备还没加载完全
    ![碧蓝航线(2) mp4_20240428_224750 336](https://github.com/LmeSzinc/AzurLaneAutoScript/assets/54128005/66190335-4596-41a3-a004-d841ffde01ef)
