### PR TITLE
Feature: upper limit of errors and logs

### DIFF
--- a/alas.py
+++ b/alas.py
@@ -135,10 +135,26 @@ class AzurLaneAutoScript:
         """
         Save last 60 screenshots in ./log/error/<timestamp>
         Save logs to ./log/error/<timestamp>/log.txt
+        Save last <Error_ErrorBackupCount> error logs in ./log/error/<config-name>
         """
+        import shutil
         from module.base.utils import save_image
         from module.handler.sensitive_info import (handle_sensitive_image,
                                                    handle_sensitive_logs)
+        def keep_last_error_log(n, folder_path=f'.log/error'):
+            """
+            Args:
+                n (int): Number of error logs to keep
+                folder_path (str): Folder path
+            """
+            folders = [
+                os.path.join(folder_path, f)
+                for f in os.listdir(folder_path)
+                if os.path.isdir(os.path.join(folder_path, f))
+            ]
+            for folder in folders[:-n]:
+                shutil.rmtree(folder)
+
         if self.config.Error_SaveError:
             if not os.path.exists('./log/error'):
                 os.mkdir('./log/error')
@@ -160,6 +176,7 @@ class AzurLaneAutoScript:
                 lines = handle_sensitive_logs(lines)
             with open(f'{folder}/log.txt', 'w', encoding='utf-8') as f:
                 f.writelines(lines)
+            keep_last_error_log(self.config.Error_ErrorBackupCount, f'./log/error')
 
     def restart(self):
         from module.handler.login import LoginHandler

--- a/alas.py
+++ b/alas.py
@@ -133,15 +133,15 @@ class AzurLaneAutoScript:
 
     def save_error_log(self):
         """
-        Save last 60 screenshots in ./log/error/<timestamp>
-        Save logs to ./log/error/<timestamp>/log.txt
+        Save last 60 screenshots in ./log/error/<config-name>/<timestamp>
+        Save logs to ./log/error/<config-name>/<timestamp>/log.txt
         Save last <Error_ErrorBackupCount> error logs in ./log/error/<config-name>
         """
         import shutil
         from module.base.utils import save_image
         from module.handler.sensitive_info import (handle_sensitive_image,
                                                    handle_sensitive_logs)
-        def keep_last_error_log(n, folder_path=f'.log/error'):
+        def keep_last_error_log(n, folder_path=f'.log/error/{self.config_name}'):
             """
             Args:
                 n (int): Number of error logs to keep
@@ -156,9 +156,9 @@ class AzurLaneAutoScript:
                 shutil.rmtree(folder)
 
         if self.config.Error_SaveError:
-            if not os.path.exists('./log/error'):
-                os.mkdir('./log/error')
-            folder = f'./log/error/{int(time.time() * 1000)}'
+            if not os.path.exists(f'./log/error/{self.config_name}'):
+                os.makedirs(f'./log/error/{self.config_name}')
+            folder = f'./log/error/{self.config_name}/{int(time.time() * 1000)}'
             logger.warning(f'Saving error: {folder}')
             os.mkdir(folder)
             for data in self.device.screenshot_deque:
@@ -170,13 +170,13 @@ class AzurLaneAutoScript:
                 start = 0
                 for index, line in enumerate(lines):
                     line = line.strip(' \r\t\n')
-                    if re.match('^═{15,}$', line):
+                    if re.search(r'\[bold\](.*?)\[/bold\]', line):
                         start = index
-                lines = lines[start - 2:]
+                lines = lines[start:]
                 lines = handle_sensitive_logs(lines)
             with open(f'{folder}/log.txt', 'w', encoding='utf-8') as f:
                 f.writelines(lines)
-            keep_last_error_log(self.config.Error_ErrorBackupCount, f'./log/error')
+            keep_last_error_log(self.config.Error_ErrorBackupCount, f'./log/error/{self.config_name}')
 
     def restart(self):
         from module.handler.login import LoginHandler

--- a/config/deploy.template-AidLux-cn.yaml
+++ b/config/deploy.template-AidLux-cn.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template-AidLux.yaml
+++ b/config/deploy.template-AidLux.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template-cn.yaml
+++ b/config/deploy.template-cn.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template-docker-cn.yaml
+++ b/config/deploy.template-docker-cn.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template-docker.yaml
+++ b/config/deploy.template-docker.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template-linux-cn.yaml
+++ b/config/deploy.template-linux-cn.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template-linux.yaml
+++ b/config/deploy.template-linux.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/deploy.template.yaml
+++ b/config/deploy.template.yaml
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/config/template.json
+++ b/config/template.json
@@ -18,7 +18,8 @@
       "HandleError": true,
       "SaveError": true,
       "OnePushConfig": "provider: null",
-      "ScreenshotLength": 1
+      "ScreenshotLength": 1,
+      "ErrorBackupCount": 30
     },
     "Optimization": {
       "ScreenshotInterval": 0.3,

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -64,6 +64,8 @@ class ConfigModel:
     # Dynamic
     GitOverCdn: bool = False
 
+    #Log
+    LogBackupCount = 7
 
 class DeployConfig(ConfigModel):
     def __init__(self, file=DEPLOY_CONFIG):

--- a/deploy/template
+++ b/deploy/template
@@ -157,3 +157,8 @@ Deploy:
     # '["alas"]' specified "alas" config
     # '["alas","alas2"]' specified "alas" "alas2" configs
     Run: null
+
+  Log:
+    # Log file backup count (Day)
+    # [In most cases] Use 7 (a week)
+    LogBackupCount: 7

--- a/gui.py
+++ b/gui.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         should_exit = False
         while not should_exit:
             event = Event()
-            process = Process(target=func, args=(event,))
+            process = Process(target=func, args=(event,), name='GUI')
             process.start()
             while not should_exit:
                 try:

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -187,6 +187,10 @@
       "ScreenshotLength": {
         "type": "input",
         "value": 1
+      },
+      "ErrorBackupCount": {
+        "type": "input",
+        "value": 30
       }
     },
     "Optimization": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -88,6 +88,7 @@ Error:
     mode: yaml
     value: 'provider: null'
   ScreenshotLength: 1
+  ErrorBackupCount: 30
 Optimization:
   ScreenshotInterval: 0.3
   CombatScreenshotInterval: 1.0

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -36,6 +36,7 @@ class GeneratedConfig:
     Error_SaveError = True
     Error_OnePushConfig = 'provider: null'
     Error_ScreenshotLength = 1
+    Error_ErrorBackupCount = 30
 
     # Group `Optimization`
     Optimization_ScreenshotInterval = 0.3

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -482,6 +482,10 @@
     "ScreenshotLength": {
       "name": "Record Screenshot(s)",
       "help": "Number of screenshots saved when exception occurs"
+    },
+    "ErrorBackupCount": {
+      "name": "Upper limit of error log storage",
+      "help": "Alas will only save a maximum of X error logs"
     }
   },
   "Optimization": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -482,6 +482,10 @@
     "ScreenshotLength": {
       "name": "Error.ScreenshotLength.name",
       "help": "Error.ScreenshotLength.help"
+    },
+    "ErrorBackupCount": {
+      "name": "Error.ErrorBackupCount.name",
+      "help": "Error.ErrorBackupCount.help"
     }
   },
   "Optimization": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -482,6 +482,10 @@
     "ScreenshotLength": {
       "name": "出错时，保留最后 X 张截图",
       "help": ""
+    },
+    "ErrorBackupCount": {
+      "name": "错误日志存储上限",
+      "help": "总共保存 X 份错误日志（超出部分将删除）"
     }
   },
   "Optimization": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -482,6 +482,10 @@
     "ScreenshotLength": {
       "name": "出錯時，保留最後 X 張截圖",
       "help": ""
+    },
+    "ErrorBackupCount": {
+      "name": "錯誤日誌儲存上限",
+      "help": "總共保存 X 份錯誤日誌"
     }
   },
   "Optimization": {


### PR DESCRIPTION
增加两个Log存储相关的选项 

- 错误Log文件夹上限
<img width="386" alt="image" src="https://github.com/LmeSzinc/AzurLaneAutoScript/assets/72910756/bb22d5f5-a387-4e78-8684-b6f6ae92258e">

- 日志文件上限
<img width="581" alt="image" src="https://github.com/LmeSzinc/AzurLaneAutoScript/assets/72910756/8d1d9a51-6e14-4c83-974a-9cf05b67c924">

可能存在的问题：
更换了`logger`的`filehandle`可能会导致一些控制台能输出的富文本信息存不到文件中。