### PR TITLE
Upd: Support MAA v5.2.3-alpha.1.d011.g704145a3d

### DIFF
--- a/config/template.maa.json
+++ b/config/template.maa.json
@@ -156,7 +156,8 @@
       "ShiftThreshold": 4,
       "Notstationed": true,
       "Trust": true,
-      "Replenish": false
+      "Replenish": false,
+      "ContinueTraining": false
     },
     "MaaCustomInfrast": {
       "Enable": false,
@@ -182,6 +183,8 @@
       "CreditFight": false,
       "Shopping": true,
       "ForceShoppingIfCreditFull": false,
+      "OnlyBuyDiscount": false,
+      "ReserveMaxCredit": false,
       "BuyFirst": "招聘许可",
       "BlackList": "碳 > 家具 > 加急许可"
     },
@@ -197,6 +200,12 @@
       "SuccessInterval": 60,
       "FailureInterval": 120,
       "ServerUpdate": "04:00, 16:00"
+    },
+    "MaaAward": {
+      "Mail": false,
+      "Recruit": false,
+      "Orundum": false,
+      "Specialaccess": false
     },
     "Storage": {
       "Storage": {}

--- a/submodule/AlasMaaBridge/module/config/argument/args.json
+++ b/submodule/AlasMaaBridge/module/config/argument/args.json
@@ -686,6 +686,10 @@
       "Replenish": {
         "type": "checkbox",
         "value": false
+      },
+      "ContinueTraining": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "MaaCustomInfrast": {
@@ -772,6 +776,14 @@
         "type": "checkbox",
         "value": false
       },
+      "OnlyBuyDiscount": {
+        "type": "checkbox",
+        "value": false
+      },
+      "ReserveMaxCredit": {
+        "type": "checkbox",
+        "value": false
+      },
       "BuyFirst": {
         "type": "textarea",
         "value": "招聘许可"
@@ -820,6 +832,24 @@
         "type": "input",
         "value": "04:00, 16:00",
         "display": "hide"
+      }
+    },
+    "MaaAward": {
+      "Mail": {
+        "type": "checkbox",
+        "value": false
+      },
+      "Recruit": {
+        "type": "checkbox",
+        "value": false
+      },
+      "Orundum": {
+        "type": "checkbox",
+        "value": false
+      },
+      "Specialaccess": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Storage": {

--- a/submodule/AlasMaaBridge/module/config/argument/argument.yaml
+++ b/submodule/AlasMaaBridge/module/config/argument/argument.yaml
@@ -116,6 +116,7 @@ MaaInfrast:
   Notstationed: true
   Trust: true
   Replenish: false
+  ContinueTraining: false
 MaaCustomInfrast:
   Enable: false
   BuiltinConfig:
@@ -131,6 +132,8 @@ MaaMall:
   CreditFight: false
   Shopping: true
   ForceShoppingIfCreditFull: false
+  OnlyBuyDiscount: False
+  ReserveMaxCredit: False
   BuyFirst:
     value: 招聘许可
     type: textarea
@@ -158,6 +161,12 @@ MaaRoguelike:
   Support:
     value: no_use
     option: [ no_use, friend_support, nonfriend_support ]
+
+MaaAward:
+  Mail: False
+  Recruit: False
+  Orundum: False
+  Specialaccess: False
 
 # ==================== Tool ====================
 

--- a/submodule/AlasMaaBridge/module/config/argument/task.yaml
+++ b/submodule/AlasMaaBridge/module/config/argument/task.yaml
@@ -38,6 +38,7 @@ Maa:
       - MaaMall
     MaaAward:
       - Scheduler
+      - MaaAward
     MaaRoguelike:
       - Scheduler
       - MaaRoguelike

--- a/submodule/AlasMaaBridge/module/config/config_generated.py
+++ b/submodule/AlasMaaBridge/module/config/config_generated.py
@@ -76,6 +76,7 @@ class GeneratedConfig:
     MaaInfrast_Notstationed = True
     MaaInfrast_Trust = True
     MaaInfrast_Replenish = False
+    MaaInfrast_ContinueTraining = False
 
     # Group `MaaCustomInfrast`
     MaaCustomInfrast_Enable = False
@@ -88,6 +89,8 @@ class GeneratedConfig:
     MaaMall_CreditFight = False
     MaaMall_Shopping = True
     MaaMall_ForceShoppingIfCreditFull = False
+    MaaMall_OnlyBuyDiscount = False
+    MaaMall_ReserveMaxCredit = False
     MaaMall_BuyFirst = '招聘许可'
     MaaMall_BlackList = '碳 > 家具 > 加急许可'
 
@@ -101,6 +104,12 @@ class GeneratedConfig:
     MaaRoguelike_Roles = '取长补短'  # 先手必胜, 稳扎稳打, 取长补短, 随心所欲
     MaaRoguelike_CoreChar = None
     MaaRoguelike_Support = 'no_use'  # no_use, friend_support, nonfriend_support
+
+    # Group `MaaAward`
+    MaaAward_Mail = False
+    MaaAward_Recruit = False
+    MaaAward_Orundum = False
+    MaaAward_Specialaccess = False
 
     # Group `MaaCopilot`
     MaaCopilot_FileName = None

--- a/submodule/AlasMaaBridge/module/config/config_updater.py
+++ b/submodule/AlasMaaBridge/module/config/config_updater.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.append('i:/AzurLaneAutoScript')
-
 from cached_property import cached_property
 
 from module.base.timer import timer
@@ -52,7 +49,7 @@ class ConfigGenerator(config_updater.ConfigGenerator):
             deep_load(path)
             if 'option' in data:
                 deep_load(path, words=data['option'], default=False)
-        
+
         # GUI i18n
         for path, _ in deep_iter(self.gui, depth=2):
             group, key = path
@@ -127,6 +124,7 @@ if __name__ == '__main__':
     """
     # Ensure running in mod root folder
     import os
+
     os.chdir(os.path.join(os.path.dirname(__file__), "../../"))
     ConfigGenerator().generate()
     os.chdir('../../')

--- a/submodule/AlasMaaBridge/module/config/i18n/en-US.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/en-US.json
@@ -406,6 +406,10 @@
     "Replenish": {
       "name": "MaaInfrast.Replenish.name",
       "help": "MaaInfrast.Replenish.help"
+    },
+    "ContinueTraining": {
+      "name": "MaaInfrast.ContinueTraining.name",
+      "help": "MaaInfrast.ContinueTraining.help"
     }
   },
   "MaaCustomInfrast": {
@@ -456,6 +460,14 @@
     "ForceShoppingIfCreditFull": {
       "name": "MaaMall.ForceShoppingIfCreditFull.name",
       "help": "MaaMall.ForceShoppingIfCreditFull.help"
+    },
+    "OnlyBuyDiscount": {
+      "name": "MaaMall.OnlyBuyDiscount.name",
+      "help": "MaaMall.OnlyBuyDiscount.help"
+    },
+    "ReserveMaxCredit": {
+      "name": "MaaMall.ReserveMaxCredit.name",
+      "help": "MaaMall.ReserveMaxCredit.help"
     },
     "BuyFirst": {
       "name": "MaaMall.BuyFirst.name",
@@ -531,6 +543,28 @@
       "no_use": "no_use",
       "friend_support": "friend_support",
       "nonfriend_support": "nonfriend_support"
+    }
+  },
+  "MaaAward": {
+    "_info": {
+      "name": "MaaAward._info.name",
+      "help": "MaaAward._info.help"
+    },
+    "Mail": {
+      "name": "MaaAward.Mail.name",
+      "help": "MaaAward.Mail.help"
+    },
+    "Recruit": {
+      "name": "MaaAward.Recruit.name",
+      "help": "MaaAward.Recruit.help"
+    },
+    "Orundum": {
+      "name": "MaaAward.Orundum.name",
+      "help": "MaaAward.Orundum.help"
+    },
+    "Specialaccess": {
+      "name": "MaaAward.Specialaccess.name",
+      "help": "MaaAward.Specialaccess.help"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/config/i18n/ja-JP.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/ja-JP.json
@@ -406,6 +406,10 @@
     "Replenish": {
       "name": "MaaInfrast.Replenish.name",
       "help": "MaaInfrast.Replenish.help"
+    },
+    "ContinueTraining": {
+      "name": "MaaInfrast.ContinueTraining.name",
+      "help": "MaaInfrast.ContinueTraining.help"
     }
   },
   "MaaCustomInfrast": {
@@ -456,6 +460,14 @@
     "ForceShoppingIfCreditFull": {
       "name": "MaaMall.ForceShoppingIfCreditFull.name",
       "help": "MaaMall.ForceShoppingIfCreditFull.help"
+    },
+    "OnlyBuyDiscount": {
+      "name": "MaaMall.OnlyBuyDiscount.name",
+      "help": "MaaMall.OnlyBuyDiscount.help"
+    },
+    "ReserveMaxCredit": {
+      "name": "MaaMall.ReserveMaxCredit.name",
+      "help": "MaaMall.ReserveMaxCredit.help"
     },
     "BuyFirst": {
       "name": "MaaMall.BuyFirst.name",
@@ -531,6 +543,28 @@
       "no_use": "no_use",
       "friend_support": "friend_support",
       "nonfriend_support": "nonfriend_support"
+    }
+  },
+  "MaaAward": {
+    "_info": {
+      "name": "MaaAward._info.name",
+      "help": "MaaAward._info.help"
+    },
+    "Mail": {
+      "name": "MaaAward.Mail.name",
+      "help": "MaaAward.Mail.help"
+    },
+    "Recruit": {
+      "name": "MaaAward.Recruit.name",
+      "help": "MaaAward.Recruit.help"
+    },
+    "Orundum": {
+      "name": "MaaAward.Orundum.name",
+      "help": "MaaAward.Orundum.help"
+    },
+    "Specialaccess": {
+      "name": "MaaAward.Specialaccess.name",
+      "help": "MaaAward.Specialaccess.help"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/config/i18n/zh-CN.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/zh-CN.json
@@ -66,7 +66,7 @@
     },
     "Enable": {
       "name": "启用该功能",
-      "help": "将这个任务加入调度器\n委托、科研、收获任务是强制打开的"
+      "help": "将这个任务加入调度器\n开始唤醒是强制打开的"
     },
     "NextRun": {
       "name": "下一次运行时间",
@@ -406,6 +406,10 @@
     "Replenish": {
       "name": "源石碎片自动补货",
       "help": ""
+    },
+    "ContinueTraining": {
+      "name": "训练完成后继续尝试专精当前技能",
+      "help": ""
     }
   },
   "MaaCustomInfrast": {
@@ -456,6 +460,14 @@
     "ForceShoppingIfCreditFull": {
       "name": "信用溢出时无视黑名单",
       "help": ""
+    },
+    "OnlyBuyDiscount": {
+      "name": "只购买打折的信用商品",
+      "help": ""
+    },
+    "ReserveMaxCredit": {
+      "name": "300以下信用点停止买商品",
+      "help": "300以下信用点停止买商品"
     },
     "BuyFirst": {
       "name": "优先购买",
@@ -531,6 +543,28 @@
       "no_use": "不使用",
       "friend_support": "好友助战",
       "nonfriend_support": "好友+非好友助战"
+    }
+  },
+  "MaaAward": {
+    "_info": {
+      "name": "领取日常奖励",
+      "help": ""
+    },
+    "Mail": {
+      "name": "领取所有邮件奖励",
+      "help": ""
+    },
+    "Recruit": {
+      "name": "进行限定池赠送的每日免费单抽",
+      "help": "该功能属于危险功能，可能会造成误抽\n若不存在免费单抽，则不会抽取"
+    },
+    "Orundum": {
+      "name": "领取幸运墙的每日合成玉奖励",
+      "help": ""
+    },
+    "Specialaccess": {
+      "name": "领取五周年赠送月卡奖励",
+      "help": ""
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/config/i18n/zh-TW.json
+++ b/submodule/AlasMaaBridge/module/config/i18n/zh-TW.json
@@ -406,6 +406,10 @@
     "Replenish": {
       "name": "MaaInfrast.Replenish.name",
       "help": "MaaInfrast.Replenish.help"
+    },
+    "ContinueTraining": {
+      "name": "MaaInfrast.ContinueTraining.name",
+      "help": "MaaInfrast.ContinueTraining.help"
     }
   },
   "MaaCustomInfrast": {
@@ -456,6 +460,14 @@
     "ForceShoppingIfCreditFull": {
       "name": "MaaMall.ForceShoppingIfCreditFull.name",
       "help": "MaaMall.ForceShoppingIfCreditFull.help"
+    },
+    "OnlyBuyDiscount": {
+      "name": "MaaMall.OnlyBuyDiscount.name",
+      "help": "MaaMall.OnlyBuyDiscount.help"
+    },
+    "ReserveMaxCredit": {
+      "name": "MaaMall.ReserveMaxCredit.name",
+      "help": "MaaMall.ReserveMaxCredit.help"
     },
     "BuyFirst": {
       "name": "MaaMall.BuyFirst.name",
@@ -531,6 +543,28 @@
       "no_use": "no_use",
       "friend_support": "friend_support",
       "nonfriend_support": "nonfriend_support"
+    }
+  },
+  "MaaAward": {
+    "_info": {
+      "name": "MaaAward._info.name",
+      "help": "MaaAward._info.help"
+    },
+    "Mail": {
+      "name": "MaaAward.Mail.name",
+      "help": "MaaAward.Mail.help"
+    },
+    "Recruit": {
+      "name": "MaaAward.Recruit.name",
+      "help": "MaaAward.Recruit.help"
+    },
+    "Orundum": {
+      "name": "MaaAward.Orundum.name",
+      "help": "MaaAward.Orundum.help"
+    },
+    "Specialaccess": {
+      "name": "MaaAward.Specialaccess.name",
+      "help": "MaaAward.Specialaccess.help"
     }
   },
   "MaaCopilot": {

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -328,7 +328,8 @@ class AssistantHandler:
             "threshold": self.config.MaaInfrast_WorkThreshold / 24,
             "replenish": self.config.MaaInfrast_Replenish,
             "dorm_notstationed_enabled": self.config.MaaInfrast_Notstationed,
-            "dorm_trust_enabled": self.config.MaaInfrast_Trust
+            "dorm_trust_enabled": self.config.MaaInfrast_Trust,
+            "continue_train": self.config.MaaInfrast_ContinueTraining
         }
 
         if self.config.MaaCustomInfrast_Enable:
@@ -417,14 +418,22 @@ class AssistantHandler:
             "shopping": self.config.MaaMall_Shopping,
             "buy_first": buy_first,
             "blacklist": blacklist,
-            "force_shopping_if_credit_full": self.config.MaaMall_ForceShoppingIfCreditFull
+            "force_shopping_if_credit_full": self.config.MaaMall_ForceShoppingIfCreditFull,
+            "only_buy_discount": self.config.MaaMall_OnlyBuyDiscount,
+            "reserve_max_credit": self.config.MaaMall_ReserveMaxCredit,
         })
         self.config.task_delay(server_update=True)
 
     def award(self):
-        self.maa_start('Award', {
-            "enable": True
-        })
+        args = {
+            "enable": True,
+            "award": True,
+            "mail": self.config.MaaAward_Mail,
+            "recruit": self.config.MaaAward_Recruit,
+            "orundum": self.config.MaaAward_Orundum,
+            "specialaccess": self.config.MaaAward_Specialaccess,
+        }
+        self.maa_start('Award', args)
         self.config.task_delay(server_update=True)
 
     def roguelike(self):


### PR DESCRIPTION
更正部分文本

新增以下功能：
- 基建换班 - 训练完成后继续尝试专精当前技能
- 收取信用及购物 - 只购买打折的信用商品 
- 收取信用及购物 - 300以下信用点停止买商品
- 领取日常奖励 - 领取所有邮件奖励
- 领取日常奖励 - 进行限定池赠送的每日免费单抽
- 领取日常奖励 - 领取幸运墙的每日合成玉奖励
- 领取日常奖励 - 领取五周年赠送月卡奖励