### PR TITLE
Fix: avoid continuous clicking AUTO_SEARCH_OS_MAP_OPTION_OFF

### DIFF
--- a/module/os_handler/map_event.py
+++ b/module/os_handler/map_event.py
@@ -271,11 +271,13 @@ class MapEventHandler(EnemySearchingHandler):
             if self.appear(AUTO_SEARCH_OS_MAP_OPTION_OFF, offset=(5, 120), interval=3) \
                     and AUTO_SEARCH_OS_MAP_OPTION_OFF.match_appear_on(self.device.image):
                 self.device.click(AUTO_SEARCH_OS_MAP_OPTION_OFF)
+                self.interval_reset(AUTO_SEARCH_OS_MAP_OPTION_OFF_DISABLED)
                 return True
             # Game client bugged sometimes, AUTO_SEARCH_OS_MAP_OPTION_OFF grayed out but still functional
             if self.appear(AUTO_SEARCH_OS_MAP_OPTION_OFF_DISABLED, offset=(5, 120), interval=3) \
                     and AUTO_SEARCH_OS_MAP_OPTION_OFF_DISABLED.match_appear_on(self.device.image):
                 self.device.click(AUTO_SEARCH_OS_MAP_OPTION_OFF_DISABLED)
+                self.interval_reset(AUTO_SEARCH_OS_MAP_OPTION_OFF)
                 return True
         else:
             if self.appear(AUTO_SEARCH_OS_MAP_OPTION_ON, offset=(5, 120), interval=3) \


### PR DESCRIPTION
避免在fast PC上出现这样的点击

```Text
─────────────────────────────────────────────────── OS AUTO SEARCH ────────────────────────────────────────────────────
2024-05-23 00:12:29.565 | INFO | OS AUTO SEARCH                                                                        
2024-05-23 00:12:29.577 | INFO | Click (1232,  540) @ AUTO_SEARCH_OS_MAP_OPTION_OFF                                    
2024-05-23 00:12:29.653 | INFO | Click (1237,  539) @ AUTO_SEARCH_OS_MAP_OPTION_OFF_DISABLED                           
2024-05-23 00:12:31.266 | INFO | OS auto search finished                                                               
2024-05-23 00:12:31.269 | INFO | Ash beacon status: light                                                              
2024-05-23 00:12:31.300 | INFO | [ASH_COLLECT_STATUS 0.029s] 180/200                                                   
2024-05-23 00:12:31.326 | INFO | [ASH_DAILY_STATUS 0.025s] 180/200                                                     
2024-05-23 00:12:31.331 | INFO | [HP]  98%  98%  98%  98%  98%  98%                                                    
2024-05-23 00:12:31.337 | INFO | [Repair icon] [False, False, False, False, False, False]  
```

构造出来的例子：点击后会逐渐变暗

![碧蓝航线(8) mp4_20240523_004035 498](https://github.com/LmeSzinc/AzurLaneAutoScript/assets/54128005/a151e14e-0594-4fcc-abe4-49a28049d2af)