### PR TITLE
Fix:Equipment change in slow pc

### DIFF
--- a/module/equipment/equipment_change.py
+++ b/module/equipment/equipment_change.py
@@ -140,7 +140,7 @@ class EquipmentChange(Equipment):
         """
 
         self.equipping_set(False)
-
+        self.device.sleep(0.5)
         res = cv2.matchTemplate(self.device.screenshot(), np.array(
             self.equipment_list[index]), cv2.TM_CCOEFF_NORMED)
         _, sim, _, point = cv2.minMaxLoc(res)


### PR DESCRIPTION
#3780 #3808
测了一下,这个问题八成是因为换装备的时候电脑掉帧,然后装备页面没有加载完成导致的
我实在找不到能稳定判断装备页面是否加载完成的方法,因此使用了sleep,有没有其他方法能完成