### PR TITLE
fix exception when tactical book is empty

### DIFF
--- a/module/tactical/tactical_class.py
+++ b/module/tactical/tactical_class.py
@@ -523,7 +523,7 @@ class RewardTacticalClass(Dock):
         if book_empty:
             logger.warning('Tactical books empty, delay to tomorrow')
             self.tactical_finish = get_server_next_update(self.config.Scheduler_ServerUpdate)
-            logger.info(f'Tactical finish: {[str(f) for f in self.tactical_finish]}')
+            logger.info(f'Tactical finish: {self.tactical_finish}')
         return True
 
     def _tactical_skill_select(self, selected_skill, skip_first_screenshot=True):


### PR DESCRIPTION
修复tactical功能日志输出时错误的对datetime对象进行迭代的问题