### PR TITLE
Add: more strict failure check for restart sensitive tasks

### DIFF
--- a/alas.py
+++ b/alas.py
@@ -14,6 +14,8 @@ from module.exception import *
 from module.logger import logger
 from module.notify import handle_notify
 
+RESTART_SENSITIVE_TASKS = ['OpsiObscure', 'OpsiAbyssal', 'OpsiCrossMonth']
+
 
 class AzurLaneAutoScript:
     stop_event: threading.Event = None
@@ -542,8 +544,8 @@ class AzurLaneAutoScript:
             failed = deep_get(self.failure_record, keys=task, default=0)
             failed = 0 if success else failed + 1
             deep_set(self.failure_record, keys=task, value=failed)
-            if failed >= 3:
-                logger.critical(f"Task `{task}` failed 3 or more times.")
+            if failed >= 3 or failed >= 1 and task in RESTART_SENSITIVE_TASKS:
+                logger.critical(f"Task `{task}` failed {failed} or more times.")
                 logger.critical("Possible reason #1: You haven't used it correctly. "
                                 "Please read the help text of the options.")
                 logger.critical("Possible reason #2: There is a problem with this task. "
@@ -552,7 +554,7 @@ class AzurLaneAutoScript:
                 handle_notify(
                     self.config.Error_OnePushConfig,
                     title=f"Alas <{self.config_name}> crashed",
-                    content=f"<{self.config_name}> RequestHumanTakeover\nTask `{task}` failed 3 or more times.",
+                    content=f"<{self.config_name}> RequestHumanTakeover\nTask `{task}` failed {failed} or more times.",
                 )
                 exit(1)
 


### PR DESCRIPTION
#3949 这两个月跨月都因为跳黄鸡死机白白浪费行动力和大世界每日，所以在代码里面添加了对重启敏感的任务，报错一次直接交给玩家处理