### PR TITLE
Opt: lower height value for info_bar_count

### DIFF
--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -47,7 +47,7 @@ class InfoHandler(ModuleBase):
         line = color_similarity_2d(line, color=(107, 158, 255))[:, 0]
 
         parameters = {
-            'height': 235,
+            'height': 210,
             'prominence': 50,
             # Blue lines are in a interval of 56
             'distance': 50,


### PR DESCRIPTION
大世界海域行动力识别出错，原因在于info_bar_count在长度未小于一定范围时就判断为0。
以下是几个例子：
![08-08-2024_11-19-03_PM](https://github.com/user-attachments/assets/5e9adca8-b589-4f07-97cf-fc93e333ca55)
![08-08-2024_07-54-22_AM](https://github.com/user-attachments/assets/26dc8050-22c1-41d2-bd12-f745b492a977)
建议修改对应参数以防止相关问题出现。经测试调整为210后下列图片识别info_bar_count为0，可以接受：
![10-08-2024_07-58-50_AM](https://github.com/user-attachments/assets/509655e5-5cfd-4aa0-81c1-07fd0314eb69)
![08-08-2024_01-53-46_AM](https://github.com/user-attachments/assets/6b529c72-1278-4f82-a534-e54c93537dbb)
