### PR TITLE
Fix: check rest ap even before cl1 to avoid squander

### DIFF
--- a/module/os_handler/action_point.py
+++ b/module/os_handler/action_point.py
@@ -480,7 +480,7 @@ class ActionPointHandler(UI, MapEventHandler):
 
         return True
 
-    def action_point_check(self, amount):
+    def action_point_check(self, amount, check_rest_ap=True):
         """
         Args:
             amount: Check if having this amount of action points.
@@ -491,11 +491,21 @@ class ActionPointHandler(UI, MapEventHandler):
         self.action_point_enter()
         self.action_point_safe_get()
 
-        enough = self._action_point_total > amount
-        if enough:
-            logger.info(f'Having {amount} action points')
-        else:
-            logger.info(f'Not having {amount} action points')
+        enough = False
+        if check_rest_ap:
+            diff = get_server_next_update('00:00') - datetime.now()
+            today_rest = int(diff.total_seconds() // 600)
+            enough = self._action_point_current + today_rest >= 200
+            if enough:
+                logger.info('The sum of the current action points and the rest action points'
+                            ' that can be obtained today exceeds 200, skip AP check')
+                logger.info(f'Current={self._action_point_current}  Rest={today_rest}')
+        if not enough:
+            enough = self._action_point_total > amount
+            if enough:
+                logger.info(f'Having {amount} action points')
+            else:
+                logger.info(f'Not having {amount} action points')
 
         self.action_point_quit()
         while 1:


### PR DESCRIPTION
紧急委托跑的多且开启侵蚀一的情况下容易出现行动力浪费的情况，所以有此commit。
commit的思路是调用action_point_check函数时，默认检查是否自回体力+现有体力会溢出，溢出则直接返回True。

之前lme提到，

>               刷委托和侵蚀一任务之间不存在行动力上的关联
> 
> _Originally posted by @LmeSzinc in https://github.com/LmeSzinc/AzurLaneAutoScript/issues/3182#issuecomment-1751713783_
>             

在充分利用紧急委托的情况下（即有足够多的前排保持紧急委托连转直到紧急委托过多才停止的情况下），紧急委托会出现连续可运行超过12个小时的情况（包括被更高优先级任务占用的情况，但不包括大世界任务，因为大世界任务在1000体力下会直接推迟6小时。）
考虑到侵蚀一目前是体力不足70就会开行动箱，且优先开100行动箱，那么8小时的自回体力是48，已经超出了200的上限。推迟6小时并没有让自回体力以外的体力变多，因为根本就没有运行侵蚀一，也谈不上“侵蚀一任务开启时会利用侵蚀一消耗多余体力”。

所以我建议采用此commit减少不必要的行动力浪费。