### PR TITLE
Fix: wrong popup dealing in minigame

### DIFF
--- a/module/minigame/minigame.py
+++ b/module/minigame/minigame.py
@@ -58,6 +58,8 @@ class MinigameRun(UI):
         # specific
         if self.deal_specific_popup():
             return True
+        if self.handle_popup_confirm('TICKETS_FULL'):
+            return True
         # coins more than 31, deal popup
         if self.appear_then_click(COIN_POPUP, offset=(5, 5), interval=3):
             return True


### PR DESCRIPTION
close #4130 

原来的设计会导致本月tickets达到上限的弹窗被关掉，从而回到游戏大厅，这不符合处理弹窗的目的；再加上游戏大厅里面检测MINIGAME_SCROLL.appear不安全，所以进行此更改
![2024-08-29_23-07-57-547896](https://github.com/user-attachments/assets/a7fda43c-d44f-4349-b376-b5897d0be465)
![2024-08-29_23-07-57-749204](https://github.com/user-attachments/assets/efb84f8d-e658-4c1e-9577-376fe55f2c59)
![2024-08-29_23-07-57-950505](https://github.com/user-attachments/assets/05a19dba-dcaf-4e0e-a867-83ba8f675b7e)
