### PR TITLE
Fix: ldopengl screenshot reverse color

### DIFF
--- a/module/device/method/ldopengl.py
+++ b/module/device/method/ldopengl.py
@@ -247,7 +247,7 @@ class LDOpenGLImpl:
 
         img = ctypes.cast(img_ptr, ctypes.POINTER(ctypes.c_ubyte * (height * width * 3))).contents
 
-        image = np.ctypeslib.as_array(img).reshape((height, width, 3))
+        image = np.ctypeslib.as_array(img).copy().reshape((height, width, 3))
         return image
 
     @staticmethod


### PR DESCRIPTION
可能由于雷电提供的dll中存在一定的异步行为，alas对截图的处理如果跟截图行为共用内存，有概率因为存取冲突导致截图异常
获取截图后拷贝内存可以解决这一问题，但存在一定的性能损失

先把PR开着，测试24小时没问题之后再合