### PR TITLE
Fix: interval for MISSION_OVERVIEW_ACCEPT(_SINGLE) too short

### DIFF
--- a/module/os_handler/mission.py
+++ b/module/os_handler/mission.py
@@ -194,7 +194,7 @@ class MissionHandler(GlobeOperation, ZoneManager):
                 logger.info('Unable to accept missions, because reached the maximum number of missions')
                 success = False
                 break
-            if self.appear_then_click(MISSION_OVERVIEW_ACCEPT, offset=(20, 20), interval=0.2):
+            if self.appear_then_click(MISSION_OVERVIEW_ACCEPT, offset=(20, 20), interval=2):
                 confirm_timer.reset()
                 continue
             else:
@@ -202,7 +202,7 @@ class MissionHandler(GlobeOperation, ZoneManager):
                 if confirm_timer.reached():
                     success = True
                     break
-            if self.appear_then_click(MISSION_OVERVIEW_ACCEPT_SINGLE, offset=(20, 20), interval=0.2):
+            if self.appear_then_click(MISSION_OVERVIEW_ACCEPT_SINGLE, offset=(20, 20), interval=2):
                 confirm_timer.reset()
                 continue
 


### PR DESCRIPTION
[1725116409030 (2).zip](https://github.com/user-attachments/files/16827908/1725116409030.2.zip)
```
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
                                                    OPSICROSSMONTH                                                     
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
═══════════════════════════════════════════════════════ OS INIT ═══════════════════════════════════════════════════════
2024-08-31 22:50:23.759 | INFO | OS INIT                                                                               
2024-08-31 22:50:23.791 | INFO | <<< UI ENSURE >>>                                                                     
2024-08-31 22:50:23.793 | INFO | UI get current page                                                                   
2024-08-31 22:50:23.803 | INFO | [UI] page_main                                                                        
2024-08-31 22:50:23.806 | INFO | Goto page_os                                                                          
2024-08-31 22:50:23.807 | INFO | <<< UI GOTO PAGE_OS >>>                                                               
2024-08-31 22:50:23.814 | INFO | Page switch: page_main_white -> page_campaign_menu                                    
2024-08-31 22:50:23.816 | INFO | Click (1196,  516) @ MAIN_GOTO_CAMPAIGN_WHITE                                         
2024-08-31 22:50:24.161 | INFO | Page switch: page_campaign_menu -> page_os                                            
2024-08-31 22:50:24.163 | INFO | Click ( 704,  459) @ CAMPAIGN_MENU_GOTO_OS                                            
2024-08-31 22:50:25.277 | INFO | Page arrive: page_os                                                                  
2024-08-31 22:50:25.279 | INFO | <<< ZONE INIT >>>                                                                     
2024-08-31 22:50:25.289 | INFO | Get zone name                                                                         
2024-08-31 22:50:25.395 | INFO | [MAP_NAME 0.080s] 西大陸棚D安全海域                                                   
2024-08-31 22:50:25.397 | INFO | Map name processed: 西大陸棚D                                                         
2024-08-31 22:50:25.400 | INFO | [Zone] [44|West Continental Shelf D]                                                  
────────────────────────────────────────────────── AFTER AUTO SEARCH ──────────────────────────────────────────────────
2024-08-31 22:50:25.403 | INFO | AFTER AUTO SEARCH                                                                     
2024-08-31 22:50:25.431 | INFO | No EMP debuff on current fleet                                                        
2024-08-31 22:50:25.437 | INFO | [HP]  98%  98%  98%  98%  98%  98%                                                    
2024-08-31 22:50:25.443 | INFO | [Repair icon] [False, False, False, False, False, False]                              
2024-08-31 22:50:25.446 | INFO | No ship found to be below threshold 40%, continue OS exploration                      
2024-08-31 22:50:25.447 | INFO | Handle after auto search finished, solved=False                                       
2024-08-31 22:50:25.449 | INFO | Current fleet is not afflicted with the low resolve debuff                            
2024-08-31 22:50:25.453 | INFO | In zone 22, 44, 154, skip running first auto search                                   
2024-08-31 22:50:25.455 | INFO | Ash beacon status: gray                                                               
2024-08-31 22:50:25.496 | INFO | [ASH_COLLECT_STATUS 0.039s] 0/200                                                     
2024-08-31 22:50:25.532 | INFO | [ASH_DAILY_STATUS 0.033s] 200/200                                                     
2024-08-31 22:50:25.533 | INFO | Ash beacon fully collected today                                                      
2024-08-31 22:50:25.535 | INFO | [OpsiNextReset] 2024-08-31 23:00:00                                                   
════════════════════════════════════════════════ WAIT UNTIL OPSI RESET ════════════════════════════════════════════════
2024-08-31 22:50:25.537 | INFO | WAIT UNTIL OPSI RESET                                                                 
2024-08-31 22:50:25.539 | WARNING | ALAS is now waiting for next OpSi reset, please DO NOT touch the game during wait  
2024-08-31 22:50:25.541 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:51:25.547 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:52:25.553 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:53:25.559 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:54:25.564 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:55:25.569 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:56:25.574 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:57:25.579 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:58:25.585 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 22:59:25.590 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 23:00:00.002 | INFO | Wait until 2024-08-31 23:00:00                                                        
2024-08-31 23:00:00.003 | INFO | <<< OPSI RESET >>>                                                                    
══════════════════════════════════════════════════ OPSI CLEAR DAILY ═══════════════════════════════════════════════════
2024-08-31 23:00:00.005 | INFO | OPSI CLEAR DAILY                                                                      
═════════════════════════════════════════════ OS MISSION OVERVIEW ACCEPT ══════════════════════════════════════════════
2024-08-31 23:00:00.008 | INFO | OS MISSION OVERVIEW ACCEPT                                                            
2024-08-31 23:00:00.021 | INFO | Click (1151,  679) @ MAP_GOTO_GLOBE                                                   
2024-08-31 23:00:00.666 | WARNING | Func screenshot() call timeout, retrying: 0                                        
2024-08-31 23:00:00.917 | WARNING | Func screenshot() call timeout, retrying: 0                                        
2024-08-31 23:00:02.373 | INFO | <<< UI CLICK >>>                                                                      
2024-08-31 23:00:02.396 | INFO | Click (1227,  647) @ MISSION_OVERVIEW_ENTER                                           
2024-08-31 23:00:05.605 | INFO | Click (1191,  660) @ MISSION_OVERVIEW_ENTER                                           
2024-08-31 23:00:06.814 | INFO | Click (1101,   33) @ MISSION_OVERVIEW_ACCEPT                                          
2024-08-31 23:00:07.013 | INFO | Click (1124,  139) @ MISSION_OVERVIEW_ACCEPT_SINGLE                                   
2024-08-31 23:00:07.207 | INFO | Click (1096,   27) @ MISSION_OVERVIEW_ACCEPT                                          
2024-08-31 23:00:07.405 | INFO | Click (1117,  132) @ MISSION_OVERVIEW_ACCEPT_SINGLE                                   
2024-08-31 23:00:07.606 | INFO | Click (1094,   17) @ MISSION_OVERVIEW_ACCEPT                                          
2024-08-31 23:00:07.807 | INFO | Click (1080,  136) @ MISSION_OVERVIEW_ACCEPT_SINGLE                                   
2024-08-31 23:00:08.008 | INFO | Click (1110,   31) @ MISSION_OVERVIEW_ACCEPT                                          
2024-08-31 23:00:08.206 | INFO | Click (1107,  134) @ MISSION_OVERVIEW_ACCEPT_SINGLE                                   
2024-08-31 23:00:08.408 | INFO | Click (1091,   22) @ MISSION_OVERVIEW_ACCEPT                                          
2024-08-31 23:00:08.611 | INFO | Click (1117,  134) @ MISSION_OVERVIEW_ACCEPT_SINGLE                                   
2024-08-31 23:00:08.815 | INFO | Click (1105,   38) @ MISSION_OVERVIEW_ACCEPT                                          
2024-08-31 23:00:09.018 | INFO | Function calls:                                                                       
          <string>   L1 <module>                                                                                       
          spawn.py L105 spawn_main()                                                                                   
          spawn.py L118 _main()                                                                                        
        process.py L297 _bootstrap()                                                                                   
        process.py  L99 run()                                                                                          
process_manager.py L152 run_process()                                                                                  
           alas.py L539 loop()                                                                                         
           alas.py  L71 run()                                                                                          
           alas.py L341 opsi_cross_month()                                                                             
         os_run.py L115 opsi_cross_month()                                                                             
operation_siren.py L162 os_cross_month()                                                                               
        mission.py L205 os_mission_overview_accept()                                                                   
           base.py L189 appear_then_click()                                                                            
        control.py  L37 click()                                                                                        
         device.py L251 handle_control_check()                                                                         
         device.py L293 click_record_check()                                                                           
         device.py  L44 show_function_call()                                                                           
2024-08-31 23:00:09.023 | WARNING | Too many click between 2 buttons: MISSION_OVERVIEW_ACCEPT,                         
MISSION_OVERVIEW_ACCEPT_SINGLE                                                                                         
2024-08-31 23:00:09.024 | WARNING | History click: ['MAP_GOTO_GLOBE', 'MISSION_OVERVIEW_ENTER',                        
'MISSION_OVERVIEW_ENTER', 'MISSION_OVERVIEW_ACCEPT', 'MISSION_OVERVIEW_ACCEPT_SINGLE', 'MISSION_OVERVIEW_ACCEPT',      
'MISSION_OVERVIEW_ACCEPT_SINGLE', 'MISSION_OVERVIEW_ACCEPT', 'MISSION_OVERVIEW_ACCEPT_SINGLE',                         
'MISSION_OVERVIEW_ACCEPT', 'MISSION_OVERVIEW_ACCEPT_SINGLE', 'MISSION_OVERVIEW_ACCEPT',                                
'MISSION_OVERVIEW_ACCEPT_SINGLE', 'MISSION_OVERVIEW_ACCEPT', 'MISSION_OVERVIEW_ACCEPT_SINGLE']                         
2024-08-31 23:00:09.027 | ERROR | GameTooManyClickError: Too many click between 2 buttons: MISSION_OVERVIEW_ACCEPT,    
MISSION_OVERVIEW_ACCEPT_SINGLE                                                                                         
2024-08-31 23:00:09.030 | WARNING | Saving error: ./log/error/1725116409030                                            
```