### PR TITLE
Fix: wrong campaing_main_15 enemy filter

### DIFF
--- a/campaign/campaign_main/campaign_15_base.py
+++ b/campaign/campaign_main/campaign_15_base.py
@@ -43,7 +43,7 @@ class W15GridInfo(GridInfo):
 
 
 class CampaignBase(CampaignBase_):
-    ENEMY_FILTER = '1T > 1L > 1E > 1M > 2T > 2L > 2E > 2M > 3T > 3L > 3E > 3M'
+    ENEMY_FILTER = '1L > 1M > 1E > 2L > 3L > 2M > 2E > 1C > 2C > 3M > 3E > 3C'
 
     def map_data_init(self, map_):
         super().map_data_init(map_)


### PR DESCRIPTION
修一下15图的filter。之前一直抄的14图的filter，发现没验证航空型敌人导致出现问题，修改后能验证航母类敌人。

具体排序可能还得讨论一下（如有必要）