### PR TITLE
尝试修复强化战斗中船只导致的too_many_click异常

### DIFF
--- a/module/retire/enhancement.py
+++ b/module/retire/enhancement.py
@@ -220,9 +220,12 @@ class Enhancement(Dock):
             if state == "state_enhance_check":
                 # Avoid too_many_click exception caused by multiple tries without material
                 if state_list[-2:] == ["state_enhance_recommend", "state_enhance_fail"]:
-                    if len(self.device.click_record):
-                        while self.device.click_record[-1] in ['ENHANCE_RECOMMEND', 'SHIP_SWIPE']:
-                            self.device.click_record.pop()
+                    while self.device.click_record and (self.device.click_record[-1] in ['ENHANCE_RECOMMEND', 'SHIP_SWIPE']):
+                        self.device.click_record.pop()
+                # Avoid too_many_click exception caused by enhancement failure on in-battle ships
+                elif state_list[-3:] == ["state_enhance_attempt", "state_enhance_confirm", "state_enhance_fail"]:
+                    while self.device.click_record and (self.device.click_record[-1] in ['ENHANCE_RECOMMEND', 'SHIP_SWIPE', 'ENHANCE_CONFIRM']):
+                        self.device.click_record.pop()
                 state_list.clear()
             state_list.append(state)
             if len(state_list) > 30:


### PR DESCRIPTION
关联：#4023 
主要参照原代码逻辑，对强化失败后的产生的重复无效行为进行剔除，增加失败时的"state_enhance_attempt" → "state_enhance_confirm" →"state_enhance_fail"状态链判定，在符合该状态链中，连续剔除`['ENHANCE_RECOMMEND', 'SHIP_SWIPE', 'ENHANCE_CONFIRM']`三个状态。
修改后尝试了本次活动，目前可以正常强化超过2个战斗中的船只。