### PR TITLE
Upd: In some events, ensure_auto_search_exit enters a dead loop

### DIFF
--- a/module/campaign/run.py
+++ b/module/campaign/run.py
@@ -367,7 +367,7 @@ class CampaignRun(CampaignEvent):
                     logger.info('In auto search menu, skip ensure_campaign_ui.')
                 else:
                     logger.info('In auto search menu, closing.')
-                    self.campaign.ensure_auto_search_exit()
+                    # Because event_20240725 task balancer delete self.campaign.ensure_auto_search_exit()
                     self.campaign.ensure_campaign_ui(name=self.stage, mode=mode)
             else:
                 self.campaign.ensure_campaign_ui(name=self.stage, mode=mode)


### PR DESCRIPTION
对于 #4214 
启用任务平衡时`handle_task_balancer`直接停止任务，在主线任务运行时游戏处于如下页面
![MuMu12-20240922-073642](https://github.com/user-attachments/assets/b40596c7-dd24-47c7-9e85-e71c50628b81)

此时判断到了 `AUTO_SEARCH_MENU_CONTINUE`,
<img width="69" alt="Snipaste_2024-09-22_08-10-37" src="https://github.com/user-attachments/assets/184154a0-6e2d-4f52-8a2f-51ce754af70d">
进入 `module/campaign/run.py:370` `ensure_auto_search_exit`内，
由于新活动`TEMPLATE_STAGE_CLEAR`不通用，在新活动图界面主线图的`campaign_extract_name_image`只会返回`[]`, `ensure_auto_search_exit`会陷入死循环

若是正常结束活动图，则正常执行 `ensure_campaign_ui`切换到 `page_campaign`

触发方式有3种，只有在使用`TEMPLATE_STAGE_CLEAR_20240725`的活动中才能触发:
1. 启用任务平衡，在一次活动图结束后由`handle_task_balancer`切换到任务`Main`;
2. 在活动图结算页面直接启动主线图
3. 在主线图结算页面直接启动活动图

一开始是想在`handle_task_balancer`中`task_stop()`前加一句`self.ui_goto_campaign()`，但是可能会有人触发方式2或3导致报错，`ensure_campaign_ui`里`ui_additional`已包含点击`AUTO_SEARCH_MENU_EXIT`退出结算页面，所以将370行`ensure_auto_search_exit`删除，测试了一遍上面三种情况均不会触发了，就是不知道这里的`ensure_auto_search_exit`有没有什么特殊应对情况。