### PR TITLE
Opt: save config only when campaign end

### DIFF
--- a/module/campaign/run.py
+++ b/module/campaign/run.py
@@ -390,7 +390,8 @@ class CampaignRun(CampaignEvent):
             self.device.stuck_record_clear()
             self.device.click_record_clear()
             try:
-                self.campaign.run()
+                with self.campaign.config.multi_set():
+                    self.campaign.run()
             except ScriptEnd as e:
                 logger.hr('Script end')
                 logger.info(str(e))

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -69,6 +69,9 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
             self.modified[path] = value
             if self.auto_update:
                 self.update()
+            else:
+                super().__setattr__(key, value)
+                deep_set(self.data, keys=path, value=value)
         else:
             super().__setattr__(key, value)
 


### PR DESCRIPTION
这只是一个提议，看看就好.jpg

心情控制需要每个battle都写一次文件，不存在的仪表盘在自律寻敌下也必须依赖`auto_search_watch_oil/coin`来更新，因而也需要每战写一次文件，感觉这有点太频繁了，每个campaign写一次是比较合适的、好操作的频率。

激进点的话可以dream一下在task结束时再写config（