### PR TITLE
Fix: Warning due to deprecation of "version" attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
     ALAS:
         network_mode: host


### PR DESCRIPTION
According to https://github.com/docker/compose/issues/11628#issue-2188899881

fix:
![image](https://github.com/user-attachments/assets/2111e2f0-b1a7-4bb7-a3f2-362a8dfdd26c)
