### PR TITLE
Fix: Compatible with new versions of maa

### DIFF
--- a/submodule/AlasMaaBridge/module/asst/asst.py
+++ b/submodule/AlasMaaBridge/module/asst/asst.py
@@ -50,14 +50,11 @@ class Asst:
         platform_type = platform.system().lower()
         if platform_type == 'windows':
             lib_import_func = ctypes.WinDLL
-            # Todo: MAA v4.12.0正式版更新之后删除
-            # 手动加载onnxruntime.dll以避免部分版本的python错误地从System32加载旧版本
             try:
-                lib_import_func(str(pathlib.Path(path) / 'onnxruntime.dll'))
+                # Override by System32 dll
+                lib_import_func(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
             except Exception as e:
-                print(e)
                 pass
-            # Todo
         else:
             lib_import_func = ctypes.CDLL
 


### PR DESCRIPTION
Fixes #4314 
在加载MAA前，使用来自System32的依赖覆盖掉Python自带的依赖，以解决依赖版本错误的问题