### PR TITLE
Fix: Load runtime before module PIL

### DIFF
--- a/module/webui/process_manager.py
+++ b/module/webui/process_manager.py
@@ -1,6 +1,7 @@
-import argparse
 import os
 import queue
+import ctypes
+import argparse
 import threading
 from multiprocessing import Process
 from typing import Dict, List, Union
@@ -8,6 +9,16 @@ from typing import Dict, List, Union
 import inflection
 from filelock import FileLock
 from rich.console import Console, ConsoleRenderable
+
+# This will be executed when subprocess starts
+# In order for MAA submodule to exexute,
+# it is necessary to load runtime before module PIL
+if os.name == 'nt':
+    try:
+        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/vcruntime140_1.dll'))
+        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
+    except Exception:
+        pass
 
 from module.config.utils import filepath_config
 from module.logger import logger, set_file_logger, set_func_logger

--- a/submodule/AlasMaaBridge/module/asst/asst.py
+++ b/submodule/AlasMaaBridge/module/asst/asst.py
@@ -50,14 +50,13 @@ class Asst:
         platform_type = platform.system().lower()
         if platform_type == 'windows':
             lib_import_func = ctypes.WinDLL
-            # Todo: MAA v4.12.0正式版更新之后删除
-            # 手动加载onnxruntime.dll以避免部分版本的python错误地从System32加载旧版本
             try:
-                lib_import_func(str(pathlib.Path(path) / 'onnxruntime.dll'))
-            except Exception as e:
-                print(e)
+                # Override by System32 dll
+                lib_import_func.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/vcruntime140_1.dll'))
+                lib_import_func(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
                 pass
-            # Todo
+            except Exception:
+                pass
         else:
             lib_import_func = ctypes.CDLL
 


### PR DESCRIPTION
调试环境下：执行Process会自动加载dll，后加载的dll覆盖先加载的dll，所以在加载MAA的dll前重新加载dll
实机环境下：执行Process不会自动加载dll，加载PIL库会加载dll，先加载的dll覆盖后加载的dll，由于子进程环境会从调用的当前文件开始构建，所以必须在当前文件导入含PIL的模块之前加载dll，这样加载PIL时就会自动使用已经加载了的dll