### PR TITLE
Add: fake module PIL for webui

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,8 +1,17 @@
+import sys
 import threading
+from types import ModuleType
 from multiprocessing import Event, Process
 
 from module.logger import logger
 from module.webui.setting import State
+
+# Use fake module to avoid importing unnecessary module PIL
+fake_pil_module = ModuleType('PIL')
+fake_pil_module.Image = ModuleType('PIL.Image')
+fake_pil_module.Image.Image = type('MockPILImage', (), dict(__init__=None))
+sys.modules['PIL'] = fake_pil_module
+sys.modules['PIL.Image'] = fake_pil_module.Image
 
 
 def func(ev: threading.Event):

--- a/gui.py
+++ b/gui.py
@@ -1,17 +1,8 @@
-import sys
 import threading
-from types import ModuleType
 from multiprocessing import Event, Process
 
 from module.logger import logger
 from module.webui.setting import State
-
-# Use fake module to avoid importing unnecessary module PIL
-fake_pil_module = ModuleType('PIL')
-fake_pil_module.Image = ModuleType('PIL.Image')
-fake_pil_module.Image.Image = type('MockPILImage', (), dict(__init__=None))
-sys.modules['PIL'] = fake_pil_module
-sys.modules['PIL.Image'] = fake_pil_module.Image
 
 
 def func(ev: threading.Event):

--- a/module/submodule/submodule.py
+++ b/module/submodule/submodule.py
@@ -1,6 +1,5 @@
 import importlib
 
-from module.config.config import AzurLaneConfig
 from module.logger import logger
 from module.submodule.utils import *
 
@@ -15,6 +14,8 @@ def load_mod(name):
 
 
 def load_config(config_name):
+    from module.config.config import AzurLaneConfig
+
     mod_name = get_config_mod(config_name)
     if mod_name == 'alas':
         return AzurLaneConfig(config_name, '')

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -1,11 +1,17 @@
-import argparse
+import sys
 import json
-import queue
-import threading
 import time
+import queue
+import argparse
+import threading
+
 from datetime import datetime
 from functools import partial
 from typing import Dict, List, Optional
+
+# Import fake module before import pywebio to avoid importing unnecessary module PIL
+from module.webui.fake_pil_module import import_fake_pil_module
+import_fake_pil_module()
 
 from pywebio import config as webconfig
 from pywebio.input import file_upload, input, input_group, select

--- a/module/webui/fake_pil_module.py
+++ b/module/webui/fake_pil_module.py
@@ -1,0 +1,15 @@
+import sys
+from types import ModuleType
+
+
+def import_fake_pil_module():
+    fake_pil_module = ModuleType('PIL')
+    fake_pil_module.Image = ModuleType('PIL.Image')
+    fake_pil_module.Image.Image = type('MockPILImage', (), dict(__init__=None))
+    sys.modules['PIL'] = fake_pil_module
+    sys.modules['PIL.Image'] = fake_pil_module.Image
+
+
+def remove_fake_pil_module():
+    sys.modules.pop('PIL', None)
+    sys.modules.pop('PIL.Image', None)

--- a/module/webui/process_manager.py
+++ b/module/webui/process_manager.py
@@ -1,6 +1,7 @@
-import argparse
 import os
+import sys
 import queue
+import argparse
 import threading
 from multiprocessing import Process
 from typing import Dict, List, Union
@@ -140,6 +141,10 @@ class ProcessManager:
         set_func_logger(func=q.put)
 
         from module.config.config import AzurLaneConfig
+
+        # Remove fake PIL module, because subprocess will use it
+        sys.modules.pop('PIL', None)
+        sys.modules.pop('PIL.Image', None)
 
         AzurLaneConfig.stop_event = e
         try:

--- a/module/webui/process_manager.py
+++ b/module/webui/process_manager.py
@@ -10,6 +10,12 @@ import inflection
 from filelock import FileLock
 from rich.console import Console, ConsoleRenderable
 
+# Since this file does not run under the same process or subprocess of app.py
+# the following code needs to be repeated
+# Import fake module before import pywebio to avoid importing unnecessary module PIL
+from module.webui.fake_pil_module import *
+import_fake_pil_module()
+
 from module.config.utils import filepath_config
 from module.logger import logger, set_file_logger, set_func_logger
 from module.submodule.submodule import load_mod
@@ -143,8 +149,7 @@ class ProcessManager:
         from module.config.config import AzurLaneConfig
 
         # Remove fake PIL module, because subprocess will use it
-        sys.modules.pop('PIL', None)
-        sys.modules.pop('PIL.Image', None)
+        remove_fake_pil_module()
 
         AzurLaneConfig.stop_event = e
         try:

--- a/submodule/AlasMaaBridge/maa.py
+++ b/submodule/AlasMaaBridge/maa.py
@@ -3,17 +3,26 @@ import json
 import ctypes
 from cached_property import cached_property
 
+# In order for MAA submodule to exexute,
+# it is necessary to load runtime before module PIL
 if os.name == 'nt':
+    # This DLL is the dependency for next DLL
+    # Try loading to avoid mix different versions of runtime
     try:
-        # In order for MAA submodule to exexute,
-        # it is necessary to load runtime before module PIL
         ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/vcruntime140_1.dll'))
-        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
+    except Exception as e:
+        print(e)
+
+    # This DLL must be loaded due to conflict issues
+    ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
+
+    # These DLLS are other DLLS that MAA depends on
+    # Try loading to avoid mix different versions of runtime
+    try:
         ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140_1.dll'))
         ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/concrt140.dll'))
-        pass
-    except Exception:
-        pass
+    except Exception as e:
+        print(e)
 
 from alas import AzurLaneAutoScript
 from module.exception import RequestHumanTakeover

--- a/submodule/AlasMaaBridge/maa.py
+++ b/submodule/AlasMaaBridge/maa.py
@@ -1,7 +1,19 @@
 import os
 import json
-
+import ctypes
 from cached_property import cached_property
+
+if os.name == 'nt':
+    try:
+        # In order for MAA submodule to exexute,
+        # it is necessary to load runtime before module PIL
+        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/vcruntime140_1.dll'))
+        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
+        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140_1.dll'))
+        ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/concrt140.dll'))
+        pass
+    except Exception:
+        pass
 
 from alas import AzurLaneAutoScript
 from module.exception import RequestHumanTakeover

--- a/submodule/AlasMaaBridge/module/asst/asst.py
+++ b/submodule/AlasMaaBridge/module/asst/asst.py
@@ -50,11 +50,6 @@ class Asst:
         platform_type = platform.system().lower()
         if platform_type == 'windows':
             lib_import_func = ctypes.WinDLL
-            try:
-                # Override by System32 dll
-                lib_import_func(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
-            except Exception as e:
-                pass
         else:
             lib_import_func = ctypes.CDLL
 

--- a/submodule/AlasMaaBridge/module/handler/handler.py
+++ b/submodule/AlasMaaBridge/module/handler/handler.py
@@ -31,7 +31,12 @@ class AssistantHandler:
         AssistantHandler.Asst = asst.Asst
         AssistantHandler.Message = utils.Message
         AssistantHandler.InstanceOptionType = utils.InstanceOptionType
-        AssistantHandler.Asst.load(path, user_dir=path, incremental_path=incremental_path)
+        try:
+            AssistantHandler.Asst.load(path, user_dir=path, incremental_path=incremental_path)
+        except OSError as e:
+            logger.critical(e)
+            logger.critical("MAA加载失败，请检查MAA本体能否正常打开")
+            raise RequestHumanTakeover
 
         AssistantHandler.ASST_HANDLER = None
 


### PR DESCRIPTION
#4314
在经历了漫长的试错之后，总算对这个问题有了正确的认识，整个问题分为两部分，
1.正常情况下，PIL库加载的时候会加载自己的msvcp140.dll，pywebio库依赖于PIL库的typehint，但是没有实际使用PIL库中的内容，multiprocessing.Process在启动子进程的时候会根据调用文件加载环境，意外加载了PIL库，导致MAA的dll加载时出现依赖版本冲突
2.Pycharm调试的情况下，multiprocessing.Process在启动子进程的时候会加载Python内置的msvcp140.dll，也会导致MAA的dll加载时出现依赖版本冲突

这个pr解决了正常情况下的依赖版本冲突问题：
在主进程启动的时候填充假的PIL库，避免主进程加载不必要的PIL库，也避免了子进程在启动的时候加载PIL库
在子进程启动完成后删除继承到的假的PIL库，Alas实例可以在需要的情况下重新加载真实的PIL库
在MAA实例启动后，加载PIL库之前，抢先加载正确版本的运行库
为了避免可能存在的不同版本运行库混用的问题，我根据MAA的dll依赖，加载了全套的运行库
但是由于vcruntime140.dll跟Python绑定非常深，无法通过直接替换文件以外的方式解决，所以还是没法完全避免混用
混用不一定会导致问题，需要一段时间的测试，保证MAA调用到的所有运行库成员在当前dll里面有就行

调试状态下的问题因为比较底层，所以没法给出项目内的解决方案，如果想要使用调试，可以通过在Python根目录\Lib\site-packages下建立sitecustomize.py文件，然后编辑为类似
import os
import ctypes
ctypes.WinDLL(os.path.join(os.environ['SystemRoot'], 'System32/msvcp140.dll'))
的内容，抢在Process调用内置版本的dll之前，先调用正确版本的dll，就可以解决版本冲突的问题

这次吸取教训，已经在真实的Alas懒人包下面测试过了，应该没有问题，但最好还是再多测试一下