### PR TITLE
修正日版部分委託名稱偵測錯誤導致委託失敗的bug

### DIFF
--- a/module/base/utils.py
+++ b/module/base/utils.py
@@ -3,6 +3,7 @@ import re
 import cv2
 import numpy as np
 from PIL import Image
+from difflib import SequenceMatcher
 
 REGEX_NODE = re.compile(r'(-?[A-Za-z]+)(-?\d+)')
 
@@ -971,3 +972,6 @@ def color_bar_percentage(image, area, prev_color, reverse=False, starter=0, thre
         prev_color = np.mean(image[:, left:prev_index + 1][mask], axis=0)
 
     return 0.
+
+def diff_string(a,b):
+    return SequenceMatcher(None,a,b).ratio()

--- a/module/commission/commission.py
+++ b/module/commission/commission.py
@@ -28,6 +28,8 @@ COMMISSION_SWITCH.add_status('daily', COMMISSION_DAILY)
 COMMISSION_SWITCH.add_status('urgent', COMMISSION_URGENT)
 COMMISSION_SCROLL = Scroll(COMMISSION_SCROLL_AREA, color=(247, 211, 66), name='COMMISSION_SCROLL')
 
+# threshold for current selected commision to be correct
+COMMISSION_NAME_MATCH_RATE = 0.95
 
 def lines_detect(image):
     """
@@ -385,10 +387,11 @@ class RewardCommission(UI, InfoHandler):
                     current.call('convert_to_night')  # Convert extra commission to night
                 if current.count >= 1:
                     current = current[0]
-                    if current == comm:
-                        logger.info('Selected to the correct commission')
+                    ratio   = diff_string(str(current), str(comm))
+                    if ratio >= COMMISSION_NAME_MATCH_RATE:
+                        logger.info(f'Selected to the correct commission (r={ratio})')
                     else:
-                        logger.warning('Selected to the wrong commission')
+                        logger.warning(f'Selected to the wrong commission, wanted `{comm}` but got `{current}` (r={ratio})')
                         return False
                 else:
                     logger.warning('No selected commission detected, assuming correct')
@@ -430,8 +433,11 @@ class RewardCommission(UI, InfoHandler):
                 # In different scans, they have the same information, but have different locations.
                 current = None
                 for new_comm in new:
-                    if new_comm == comm:
+                    ratio = diff_string(str(new_comm), str(comm))
+                    if ratio >= COMMISSION_NAME_MATCH_RATE:
+                        logger.info(f'Selecting commission {new_comm} (r={ratio})')
                         current = new_comm
+                        break
                 if current is not None:
                     if self._commission_start_click(current, is_urgent=is_urgent):
                         self.device.click_record_clear()


### PR DESCRIPTION
RT,

改善後的 logging 訊息為下
```
2024-12-08 13:45:09.843 | INFO | [Commission] 小型油田開発皿 |  (Genre: extra_oil, Status: pending, Duration: 1:00:00) 
2024-12-08 13:45:09.847 | WARNING | Selected to the wrong commission, wanted `小型油田開発皿 | Ⅰ (Genre: extra_oil,     
Status: pending, Duration: 1:00:00)` but got `小型油田開発皿 |  (Genre: extra_oil, Status: pending, Duration: 1:00:00)`
```
因部分委託名稱無法完全偵測，導致名稱不符進而無法順利跑委託
詢問自身群友也有相同問題

所以改用文字相似度邏輯判斷，預設相似度 95% 以上時視為委託正確，
但這樣可能有極小概率跑錯委託，但比不跑強