### PR TITLE
Tmp: resume low hp detection after false BATTLE_STATUS

### DIFF
--- a/module/exercise/combat.py
+++ b/module/exercise/combat.py
@@ -53,6 +53,8 @@ class ExerciseCombat(HpDaemon, OpponentChoose, ExerciseEquipment, Combat):
 
             p = self.is_combat_executing()
             if p:
+                if end:
+                    end = False
                 if pause is None:
                     pause = p
             else:


### PR DESCRIPTION
演习中途会遇到误识别BATTLE_STATUS_D的情况，原因有待排查，但这个bug存在会导致抓瞎，极大影响演习撤退的功能，因此提出此临时修改。

修改前：
![D5E1R1TFC$3HA0Z{SKFZ$JB](https://github.com/user-attachments/assets/bcf283c2-2576-4558-95f1-b2e7f612e787)

修改后：
![Z H~4L)PYNR}G)E 4PZT2MG](https://github.com/user-attachments/assets/a5eaa328-efa5-4866-b14a-33992612ef0d)
