### PR TITLE
Revert JP commission ocr modification

### DIFF
--- a/module/commission/project.py
+++ b/module/commission/project.py
@@ -36,13 +36,6 @@ class SuffixOcr(Ocr):
         if len(left):
             image = image[:, left[-1] - look_back:]
 
-        if server.server in ['jp']:
-            # slice top and bottom part to get clearer roman digits
-            # will need to pad white background for better recognization
-            image = image[8:-10, :]
-            cv2.normalize(image, image, -55, 255, cv2.NORM_MINMAX)
-            image = (image > 128).astype(np.uint8) * 255
-            image = np.pad(image, ((4, 4), (0, 0)), mode='constant', constant_values=255)
         return image
 
 
@@ -174,7 +167,7 @@ class Commission:
         self.genre = self.commission_name_parse(self.name)
 
         # Suffix
-        ocr = SuffixOcr(button, lang='azur_lane', letter=(201, 201, 201), threshold=128, alphabet='IV')
+        ocr = SuffixOcr(button, lang='azur_lane', letter=(255, 255, 255), threshold=128, alphabet='IV')
         self.suffix = self.beautify_name(ocr.ocr(self.image))
 
         # Duration time

--- a/module/commission/project.py
+++ b/module/commission/project.py
@@ -41,9 +41,8 @@ class SuffixOcr(Ocr):
             # will need to pad white background for better recognization
             image = image[8:-10, :]
             cv2.normalize(image, image, -55, 255, cv2.NORM_MINMAX)
-            image = (image > 80).astype(np.uint8) * 255
-            image = np.pad(image, ((0, 1), (0, 0)), mode='edge')
-            image = np.pad(image, ((4, 3), (0, 0)), mode='constant', constant_values=255)
+            image = (image > 128).astype(np.uint8) * 255
+            image = np.pad(image, ((4, 4), (0, 0)), mode='constant', constant_values=255)
         return image
 
 


### PR DESCRIPTION
因为#4510 的引入，原有临时脏代码失效，故回退。