### PR TITLE
Bugfix: clicking exercise button after stage 3-4

### DIFF
--- a/campaign/campaign_main/campaign_2_1.py
+++ b/campaign/campaign_main/campaign_2_1.py
@@ -1,4 +1,4 @@
-from module.campaign.campaign_base import CampaignBase
+from .campaign_2_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_2_2.py
+++ b/campaign/campaign_main/campaign_2_2.py
@@ -1,5 +1,5 @@
 from campaign.campaign_main.campaign_2_1 import Config
-from module.campaign.campaign_base import CampaignBase
+from .campaign_2_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_2_3.py
+++ b/campaign/campaign_main/campaign_2_3.py
@@ -1,5 +1,5 @@
 from campaign.campaign_main.campaign_2_1 import Config
-from module.campaign.campaign_base import CampaignBase
+from .campaign_2_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_2_4.py
+++ b/campaign/campaign_main/campaign_2_4.py
@@ -1,5 +1,5 @@
 from campaign.campaign_main.campaign_2_1 import Config as ConfigBase
-from module.campaign.campaign_base import CampaignBase
+from .campaign_2_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_2_base.py
+++ b/campaign/campaign_main/campaign_2_base.py
@@ -8,7 +8,3 @@ class CampaignBase(CampaignBase_):
         if self.ui_page_appear(page_campaign):
             return False
         return super().handle_exp_info()
-
-    def map_data_init(self, map_):
-        super().map_data_init(map_)
-        self.config.override(EnemyPriority_EnemyScaleBalanceWeight='default_mode')

--- a/campaign/campaign_main/campaign_2_base.py
+++ b/campaign/campaign_main/campaign_2_base.py
@@ -1,0 +1,14 @@
+from module.campaign.campaign_base import CampaignBase as CampaignBase_
+from module.ui.page import page_campaign
+
+
+class CampaignBase(CampaignBase_):
+    def handle_exp_info(self):
+        # Random background of Main Chapter 2 hits EXP_INFO_B
+        if self.ui_page_appear(page_campaign):
+            return False
+        return super().handle_exp_info()
+
+    def map_data_init(self, map_):
+        super().map_data_init(map_)
+        self.config.override(EnemyPriority_EnemyScaleBalanceWeight='default_mode')

--- a/campaign/campaign_main/campaign_3_1.py
+++ b/campaign/campaign_main/campaign_3_1.py
@@ -1,4 +1,4 @@
-from module.campaign.campaign_base import CampaignBase
+from .campaign_3_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_3_2.py
+++ b/campaign/campaign_main/campaign_3_2.py
@@ -1,5 +1,5 @@
 from campaign.campaign_main.campaign_3_1 import Config
-from module.campaign.campaign_base import CampaignBase
+from .campaign_3_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_3_3.py
+++ b/campaign/campaign_main/campaign_3_3.py
@@ -1,5 +1,5 @@
 from campaign.campaign_main.campaign_3_1 import Config as ConfigBase
-from module.campaign.campaign_base import CampaignBase
+from .campaign_3_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_3_4.py
+++ b/campaign/campaign_main/campaign_3_4.py
@@ -1,5 +1,5 @@
 from campaign.campaign_main.campaign_3_1 import Config as Config31
-from module.campaign.campaign_base import CampaignBase
+from .campaign_3_base import CampaignBase
 from module.logger import logger
 from module.map.map_base import CampaignMap
 from module.map.map_grids import RoadGrids, SelectedGrids

--- a/campaign/campaign_main/campaign_3_base.py
+++ b/campaign/campaign_main/campaign_3_base.py
@@ -9,7 +9,3 @@ class CampaignBase(CampaignBase_):
         if self.ui_page_appear(page_campaign):
             return False
         return super().handle_exp_info()
-
-    def map_data_init(self, map_):
-        super().map_data_init(map_)
-        self.config.override(EnemyPriority_EnemyScaleBalanceWeight='default_mode')

--- a/campaign/campaign_main/campaign_3_base.py
+++ b/campaign/campaign_main/campaign_3_base.py
@@ -1,0 +1,15 @@
+from module.campaign.campaign_base import CampaignBase as CampaignBase_
+from module.logger import logger
+from module.ui.page import page_campaign
+
+
+class CampaignBase(CampaignBase_):
+    def handle_exp_info(self):
+        # Random background of Main Chapter 3 hits EXP_INFO_B
+        if self.ui_page_appear(page_campaign):
+            return False
+        return super().handle_exp_info()
+
+    def map_data_init(self, map_):
+        super().map_data_init(map_)
+        self.config.override(EnemyPriority_EnemyScaleBalanceWeight='default_mode')

--- a/module/exercise/hp_daemon.py
+++ b/module/exercise/hp_daemon.py
@@ -1,7 +1,7 @@
 from module.base.base import ModuleBase
 from module.base.timer import Timer
 from module.base.utils import color_bar_percentage
-from module.combat_ui.assets import PAUSE, PAUSE_Christmas, PAUSE_Cyber, PAUSE_Iridescent_Fantasy, PAUSE_Neon, PAUSE_New
+from module.combat_ui.assets import PAUSE, PAUSE_Christmas, PAUSE_Cyber, PAUSE_HolyLight, PAUSE_Iridescent_Fantasy, PAUSE_Neon, PAUSE_New
 from module.exercise.assets import *
 from module.logger import logger
 
@@ -67,6 +67,7 @@ class HpDaemon(ModuleBase):
             PAUSE_Neon,
             PAUSE_Christmas,
             PAUSE_Cyber,
+            PAUSE_HolyLight
         ]:
             self.attacker_hp = self._calculate_hp(image, area=ATTACKER_HP_AREA_New.area, reverse=True)
             self.defender_hp = self._calculate_hp(image, area=DEFENDER_HP_AREA_New.area, reverse=True)

--- a/module/hard/hard.py
+++ b/module/hard/hard.py
@@ -2,6 +2,7 @@ import importlib
 
 from campaign.campaign_hard.campaign_hard import Campaign
 from module.campaign.run import CampaignRun
+from module.handler.fast_forward import to_map_file_name
 from module.hard.assets import *
 from module.logger import logger
 from module.ocr.ocr import Digit
@@ -15,8 +16,7 @@ class CampaignHard(CampaignRun):
 
     def run(self):
         logger.hr('Campaign hard', level=1)
-        chapter, stage = self.config.Hard_HardStage.split('-')
-        name = f'campaign_{chapter}_{stage}'
+        name = to_map_file_name(self.config.Hard_HardStage)
         self.config.override(
             Campaign_Mode='hard',
             Campaign_UseFleetLock=True,


### PR DESCRIPTION
Apparently clicking the exercise button was only the effect but not the cause, since exp_info_B also appears in 2-4 logs. The ultimate reason was the B in the exp info can **perfectly** integrate into the chapter background, like this:
![叠加示意图3](https://github.com/user-attachments/assets/384ab330-6305-4a3c-9f92-ff98afa5f9f9)

Commit c9fff1efa29f9e62cdf44d158f343748b2841a28 addressed this issue by moving out from the exercise page, but it just goes back in again so the program still crashes.

This commit should solve this issue for chapters 2 and 3. I did not make this solution up; instead this interesting heirarchical trick was already included in the 20221222 event. This should resolve issues #4553 #4425 #4434 .

Why this does not harm a genuine B status: because the page_campaign asset does not appear in a genuine exp info page.

BTW my branch was sync with main so I have Saar's commit here as well... Don't reckon that will be an issue?