### PR TITLE
Bugfix: Opsi Voucher Shop unable to buy coins and books

### DIFF
--- a/module/shop/shop_voucher.py
+++ b/module/shop/shop_voucher.py
@@ -204,8 +204,7 @@ class VoucherShop(ShopClerk, ShopStatus):
                 logger.info('Voucher Shop reach bottom, stop')
                 break
             else:
-                # Only 4 rows of items at max, goto bottom directly
-                VOUCHER_SHOP_SCROLL.set_bottom(main=self)
+                VOUCHER_SHOP_SCROLL.next_page(main=self)
                 del_cached_property(self, 'shop_grid')
                 del_cached_property(self, 'shop_voucher_items')
                 continue


### PR DESCRIPTION
The issue was due to a line of incorrect logic: the scroll was moved to the bottom instead of to the next page. This edit should resolve it.
I have also checked if there are similar usages of set_bottom for hardwired logic, but I found none, so only this change.
By merging this pr, issues #4550 and #4532 should be closed.