### PR TITLE
Opt: abstract CombatUI class

### DIFF
--- a/module/combat/combat.py
+++ b/module/combat/combat.py
@@ -15,7 +15,8 @@ from module.logger import logger
 from module.map.assets import MAP_OFFENSIVE
 from module.retire.retirement import Retirement
 from module.statistics.azurstats import DropImage
-from module.ui.assets import BACK_ARROW
+from module.template.assets import TEMPLATE_COMBAT_LOADING
+from module.ui.assets import BACK_ARROW, EXERCISE_CHECK, MUNITIONS_CHECK
 
 
 class Combat(Level, HPBalancer, Retirement, CombatUI, SubmarineCall, CombatAuto, CombatManual, AutoSearchHandler):
@@ -61,6 +62,30 @@ class Combat(Level, HPBalancer, Retirement, CombatUI, SubmarineCall, CombatAuto,
             # Break
             if self.combat_appear():
                 break
+
+    def is_combat_loading(self):
+        """
+        Returns:
+            bool:
+        """
+        image = self.image_crop((0, 620, 1280, 720), copy=False)
+        similarity, button = TEMPLATE_COMBAT_LOADING.match_luma_result(image)
+        if similarity > 0.85:
+            loading = (button.area[0] + 38 - LOADING_BAR.area[0]) / (LOADING_BAR.area[2] - LOADING_BAR.area[0])
+            logger.attr('Loading', f'{int(loading * 100)}%')
+            return True
+        else:
+            return False
+
+    def ensure_combat_oil_loaded(self):
+        self.wait_until_stable(COMBAT_OIL_LOADING)
+
+    def handle_combat_automation_confirm(self):
+        if self.appear(AUTOMATION_CONFIRM_CHECK, threshold=30, interval=1):
+            self.appear_then_click(AUTOMATION_CONFIRM, offset=(20, 20))
+            return True
+
+        return False
 
     def combat_preparation(self, balance_hp=False, emotion_reduce=False, auto='combat_auto', fleet_index=1):
         """
@@ -114,6 +139,16 @@ class Combat(Level, HPBalancer, Retirement, CombatUI, SubmarineCall, CombatAuto,
                 if emotion_reduce:
                     self.emotion.reduce(fleet_index)
                 break
+
+    def handle_battle_preparation(self):
+        """
+        Returns:
+            bool:
+        """
+        if self.appear_then_click(BATTLE_PREPARATION, offset=(20, 20), interval=2):
+            return True
+
+        return False
 
     def handle_combat_automation_set(self, auto):
         """
@@ -227,6 +262,148 @@ class Combat(Level, HPBalancer, Retirement, CombatUI, SubmarineCall, CombatAuto,
             if self.handle_battle_status(drop=drop) \
                     or self.handle_get_items(drop=drop):
                 break
+
+    def handle_battle_status(self, drop=None):
+        """
+        Args:
+            drop (DropImage):
+
+        Returns:
+            bool:
+        """
+        if self.is_combat_executing():
+            return False
+        if self.appear(BATTLE_STATUS_S, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_S)
+            return True
+        if self.appear(BATTLE_STATUS_A, interval=self.battle_status_click_interval):
+            logger.warning('Battle status A')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_A)
+            return True
+        if self.appear(BATTLE_STATUS_B, interval=self.battle_status_click_interval):
+            logger.warning('Battle Status B')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_B)
+            return True
+        if self.appear(BATTLE_STATUS_C, interval=self.battle_status_click_interval):
+            logger.warning('Battle Status C')
+            # raise GameStuckError('Battle status C')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_C)
+            return True
+        if self.appear(BATTLE_STATUS_D, interval=self.battle_status_click_interval):
+            logger.warning('Battle Status D')
+            # raise GameStuckError('Battle Status D')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_D)
+            return True
+
+        return False
+
+    def handle_get_items(self, drop=None):
+        """
+        Args:
+            drop (DropImage):
+
+        Returns:
+            bool:
+        """
+        if self.appear(GET_ITEMS_1, offset=5, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            self.device.click(GET_ITEMS_1)
+            self.interval_reset(BATTLE_STATUS_S)
+            self.interval_reset(BATTLE_STATUS_A)
+            self.interval_reset(BATTLE_STATUS_B)
+            return True
+        if self.appear(GET_ITEMS_2, offset=5, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            self.device.click(GET_ITEMS_1)
+            self.interval_reset(BATTLE_STATUS_S)
+            self.interval_reset(BATTLE_STATUS_A)
+            self.interval_reset(BATTLE_STATUS_B)
+            return True
+        if self.appear(GET_ITEMS_3, offset=5, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            self.device.click(GET_ITEMS_1)
+            self.interval_reset(BATTLE_STATUS_S)
+            self.interval_reset(BATTLE_STATUS_A)
+            self.interval_reset(BATTLE_STATUS_B)
+            return True
+
+        return False
+
+    def handle_exp_info(self):
+        """
+        Returns:
+            bool:
+        """
+        if self.is_combat_executing():
+            return False
+        if self.appear_then_click(EXP_INFO_S):
+            self.device.sleep((0.25, 0.5))
+            return True
+        if self.appear_then_click(EXP_INFO_A):
+            self.device.sleep((0.25, 0.5))
+            return True
+        if self.appear_then_click(EXP_INFO_B):
+            self.device.sleep((0.25, 0.5))
+            return True
+
+        return False
+
+    def handle_get_ship(self, drop=None):
+        """
+        Args:
+            drop (DropImage):
+
+        Returns:
+            bool:
+        """
+        if self.appear_then_click(GET_SHIP, interval=1):
+            if self.appear(NEW_SHIP):
+                logger.info('Get a new SHIP')
+                if drop:
+                    drop.handle_add(self)
+                self.config.GET_SHIP_TRIGGERED = True
+            return True
+
+        return False
+
+    def handle_combat_mis_click(self):
+        """
+        Returns:
+            bool:
+        """
+        if self.appear(MUNITIONS_CHECK, offset=(20, 20), interval=5):
+            logger.info(f'{MUNITIONS_CHECK} -> {BACK_ARROW}')
+            self.device.click(BACK_ARROW)
+            return True
+        if self.appear(EXERCISE_CHECK, offset=(20, 20), interval=5):
+            logger.info(f'{EXERCISE_CHECK} -> {BACK_ARROW}')
+            self.device.click(BACK_ARROW)
+            return True
+
+        return False
 
     def combat_status(self, drop=None, expected_end=None):
         """

--- a/module/combat_ui/combat_ui.py
+++ b/module/combat_ui/combat_ui.py
@@ -11,20 +11,6 @@ from module.ui.assets import BACK_ARROW, EXERCISE_CHECK, MUNITIONS_CHECK
 
 class CombatUI(ModuleBase):
     theme = None
-    
-    def is_combat_loading(self):
-        """
-        Returns:
-            bool:
-        """
-        image = self.image_crop((0, 620, 1280, 720), copy=False)
-        similarity, button = TEMPLATE_COMBAT_LOADING.match_luma_result(image)
-        if similarity > 0.85:
-            loading = (button.area[0] + 38 - LOADING_BAR.area[0]) / (LOADING_BAR.area[2] - LOADING_BAR.area[0])
-            logger.attr('Loading', f'{int(loading * 100)}%')
-            return True
-        else:
-            return False
 
     def _is_combat_executing(self, theme):
         """
@@ -40,8 +26,13 @@ class CombatUI(ModuleBase):
                     if np.max(self.image_crop(PAUSE_DOUBLE_CHECK, copy=False)) < 153:
                         return True
                 return False
-        else:
+        elif theme in ['New', 'Neon', 'Cyber', 'HolyLight']:
             return pause_template[theme].match_template_color(self.device.image, offset=(10, 10))
+        elif theme in ['Iridescent_Fantasy', 'Christmas']:
+            return pause_template[theme].match_luma(self.device.image, offset=(10, 10))
+        else:
+            logger.warning(f'Unknown combat ui theme {theme}')
+            return False
 
     def is_combat_executing(self):
         """
@@ -60,181 +51,25 @@ class CombatUI(ModuleBase):
                     self.theme = theme
                     return button
             return False
-    
+
+    def _handle_combat_quit(self, button, offset=(20, 20)):
+        if button.match_luma(self.device.image, offset=offset):
+            self.device.click(button)
+            return True
+        return False
+
     def handle_combat_quit(self, offset=(20, 20), interval=3):
         timer = self.get_interval_timer(QUIT, interval=interval)
         if not timer.reached():
             return False
         if self.theme is not None:
             quit_button = quit_template[self.theme]
-            if quit_button.match_luma(self.device.image, offset=offset):
-                self.device.click(quit_button)
+            if self._handle_combat_quit(quit_button, offset=offset):
                 timer.reset()
                 return True
         else:
-            for button in set(quit_template.values()):
-                if button.match_luma(self.device.image, offset=offset):
-                    self.device.click(button)
+            for button in quit_template.values():
+                if self._handle_combat_quit(button, offset=offset):
                     timer.reset()
                     return True
-        return False
-    
-    def ensure_combat_oil_loaded(self):
-        self.wait_until_stable(COMBAT_OIL_LOADING)
-
-    def handle_combat_automation_confirm(self):
-        if self.appear(AUTOMATION_CONFIRM_CHECK, threshold=30, interval=1):
-            self.appear_then_click(AUTOMATION_CONFIRM, offset=(20, 20))
-            return True
-        return False
-
-    def handle_battle_preparation(self):
-        """
-        Returns:
-            bool:
-        """
-        if self.appear_then_click(BATTLE_PREPARATION, offset=(20, 20), interval=2):
-            return True
-        return False
-    
-    def handle_battle_status(self, drop=None):
-        """
-        Args:
-            drop (DropImage):
-
-        Returns:
-            bool:
-        """
-        if self.is_combat_executing():
-            return False
-        if self.appear(BATTLE_STATUS_S, interval=self.battle_status_click_interval):
-            if drop:
-                drop.handle_add(self)
-            else:
-                self.device.sleep((0.25, 0.5))
-            self.device.click(BATTLE_STATUS_S)
-            return True
-        if self.appear(BATTLE_STATUS_A, interval=self.battle_status_click_interval):
-            logger.warning('Battle status A')
-            if drop:
-                drop.handle_add(self)
-            else:
-                self.device.sleep((0.25, 0.5))
-            self.device.click(BATTLE_STATUS_A)
-            return True
-        if self.appear(BATTLE_STATUS_B, interval=self.battle_status_click_interval):
-            logger.warning('Battle Status B')
-            if drop:
-                drop.handle_add(self)
-            else:
-                self.device.sleep((0.25, 0.5))
-            self.device.click(BATTLE_STATUS_B)
-            return True
-        if self.appear(BATTLE_STATUS_C, interval=self.battle_status_click_interval):
-            logger.warning('Battle Status C')
-            # raise GameStuckError('Battle status C')
-            if drop:
-                drop.handle_add(self)
-            else:
-                self.device.sleep((0.25, 0.5))
-            self.device.click(BATTLE_STATUS_C)
-            return True
-        if self.appear(BATTLE_STATUS_D, interval=self.battle_status_click_interval):
-            logger.warning('Battle Status D')
-            # raise GameStuckError('Battle Status D')
-            if drop:
-                drop.handle_add(self)
-            else:
-                self.device.sleep((0.25, 0.5))
-            self.device.click(BATTLE_STATUS_D)
-            return True
-
-        return False
-
-    def handle_get_items(self, drop=None):
-        """
-        Args:
-            drop (DropImage):
-
-        Returns:
-            bool:
-        """
-        if self.appear(GET_ITEMS_1, offset=5, interval=self.battle_status_click_interval):
-            if drop:
-                drop.handle_add(self)
-            self.device.click(GET_ITEMS_1)
-            self.interval_reset(BATTLE_STATUS_S)
-            self.interval_reset(BATTLE_STATUS_A)
-            self.interval_reset(BATTLE_STATUS_B)
-            return True
-        if self.appear(GET_ITEMS_2, offset=5, interval=self.battle_status_click_interval):
-            if drop:
-                drop.handle_add(self)
-            self.device.click(GET_ITEMS_1)
-            self.interval_reset(BATTLE_STATUS_S)
-            self.interval_reset(BATTLE_STATUS_A)
-            self.interval_reset(BATTLE_STATUS_B)
-            return True
-        if self.appear(GET_ITEMS_3, offset=5, interval=self.battle_status_click_interval):
-            if drop:
-                drop.handle_add(self)
-            self.device.click(GET_ITEMS_1)
-            self.interval_reset(BATTLE_STATUS_S)
-            self.interval_reset(BATTLE_STATUS_A)
-            self.interval_reset(BATTLE_STATUS_B)
-            return True
-
-        return False
-
-    def handle_exp_info(self):
-        """
-        Returns:
-            bool:
-        """
-        if self.is_combat_executing():
-            return False
-        if self.appear_then_click(EXP_INFO_S):
-            self.device.sleep((0.25, 0.5))
-            return True
-        if self.appear_then_click(EXP_INFO_A):
-            self.device.sleep((0.25, 0.5))
-            return True
-        if self.appear_then_click(EXP_INFO_B):
-            self.device.sleep((0.25, 0.5))
-            return True
-
-        return False
-
-    def handle_get_ship(self, drop=None):
-        """
-        Args:
-            drop (DropImage):
-
-        Returns:
-            bool:
-        """
-        if self.appear_then_click(GET_SHIP, interval=1):
-            if self.appear(NEW_SHIP):
-                logger.info('Get a new SHIP')
-                if drop:
-                    drop.handle_add(self)
-                self.config.GET_SHIP_TRIGGERED = True
-            return True
-
-        return False
-
-    def handle_combat_mis_click(self):
-        """
-        Returns:
-            bool:
-        """
-        if self.appear(MUNITIONS_CHECK, offset=(20, 20), interval=5):
-            logger.info(f'{MUNITIONS_CHECK} -> {BACK_ARROW}')
-            self.device.click(BACK_ARROW)
-            return True
-        if self.appear(EXERCISE_CHECK, offset=(20, 20), interval=5):
-            logger.info(f'{EXERCISE_CHECK} -> {BACK_ARROW}')
-            self.device.click(BACK_ARROW)
-            return True
-
         return False

--- a/module/combat_ui/combat_ui.py
+++ b/module/combat_ui/combat_ui.py
@@ -1,0 +1,240 @@
+import numpy as np
+
+from module.base.utils import color_similar, get_color
+from module.base.base import ModuleBase
+from module.combat.assets import *
+from module.combat_ui.assets import *
+from module.combat_ui.dictionary import (pause_template, quit_template)
+from module.logger import logger
+from module.template.assets import TEMPLATE_COMBAT_LOADING
+from module.ui.assets import BACK_ARROW, EXERCISE_CHECK, MUNITIONS_CHECK
+
+class CombatUI(ModuleBase):
+    theme = None
+    
+    def is_combat_loading(self):
+        """
+        Returns:
+            bool:
+        """
+        image = self.image_crop((0, 620, 1280, 720), copy=False)
+        similarity, button = TEMPLATE_COMBAT_LOADING.match_luma_result(image)
+        if similarity > 0.85:
+            loading = (button.area[0] + 38 - LOADING_BAR.area[0]) / (LOADING_BAR.area[2] - LOADING_BAR.area[0])
+            logger.attr('Loading', f'{int(loading * 100)}%')
+            return True
+        else:
+            return False
+
+    def _is_combat_executing(self, theme):
+        """
+        Returns:
+            bool:
+        """
+        if theme == 'Old':  # Old theme uses PAUSE button
+            if self.config.SERVER in ['cn', 'en']:
+                return PAUSE.match_luma(self.device.image, offset=(10, 10))
+            else:
+                color = get_color(self.device.image, PAUSE.area)
+                if color_similar(color, PAUSE.color) or color_similar(color, (238, 244, 248)):
+                    if np.max(self.image_crop(PAUSE_DOUBLE_CHECK, copy=False)) < 153:
+                        return True
+                return False
+        else:
+            return pause_template[theme].match_template_color(self.device.image, offset=(10, 10))
+
+    def is_combat_executing(self):
+        """
+        Returns:
+            Button: PAUSE button that appears
+        """
+        self.device.stuck_record_add(PAUSE)
+        if self.theme is not None:
+            if self._is_combat_executing(self.theme):
+                return pause_template[self.theme]
+            return False
+        else:
+            for theme, button in pause_template.items():
+                if self._is_combat_executing(theme):
+                    logger.info(f"Battle UI is detected as {theme}")
+                    self.theme = theme
+                    return button
+            return False
+    
+    def handle_combat_quit(self, offset=(20, 20), interval=3):
+        timer = self.get_interval_timer(QUIT, interval=interval)
+        if not timer.reached():
+            return False
+        if self.theme is not None:
+            quit_button = quit_template[self.theme]
+            if quit_button.match_luma(self.device.image, offset=offset):
+                self.device.click(quit_button)
+                timer.reset()
+                return True
+        else:
+            for button in set(quit_template.values()):
+                if button.match_luma(self.device.image, offset=offset):
+                    self.device.click(button)
+                    timer.reset()
+                    return True
+        return False
+    
+    def ensure_combat_oil_loaded(self):
+        self.wait_until_stable(COMBAT_OIL_LOADING)
+
+    def handle_combat_automation_confirm(self):
+        if self.appear(AUTOMATION_CONFIRM_CHECK, threshold=30, interval=1):
+            self.appear_then_click(AUTOMATION_CONFIRM, offset=(20, 20))
+            return True
+        return False
+
+    def handle_battle_preparation(self):
+        """
+        Returns:
+            bool:
+        """
+        if self.appear_then_click(BATTLE_PREPARATION, offset=(20, 20), interval=2):
+            return True
+        return False
+    
+    def handle_battle_status(self, drop=None):
+        """
+        Args:
+            drop (DropImage):
+
+        Returns:
+            bool:
+        """
+        if self.is_combat_executing():
+            return False
+        if self.appear(BATTLE_STATUS_S, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_S)
+            return True
+        if self.appear(BATTLE_STATUS_A, interval=self.battle_status_click_interval):
+            logger.warning('Battle status A')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_A)
+            return True
+        if self.appear(BATTLE_STATUS_B, interval=self.battle_status_click_interval):
+            logger.warning('Battle Status B')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_B)
+            return True
+        if self.appear(BATTLE_STATUS_C, interval=self.battle_status_click_interval):
+            logger.warning('Battle Status C')
+            # raise GameStuckError('Battle status C')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_C)
+            return True
+        if self.appear(BATTLE_STATUS_D, interval=self.battle_status_click_interval):
+            logger.warning('Battle Status D')
+            # raise GameStuckError('Battle Status D')
+            if drop:
+                drop.handle_add(self)
+            else:
+                self.device.sleep((0.25, 0.5))
+            self.device.click(BATTLE_STATUS_D)
+            return True
+
+        return False
+
+    def handle_get_items(self, drop=None):
+        """
+        Args:
+            drop (DropImage):
+
+        Returns:
+            bool:
+        """
+        if self.appear(GET_ITEMS_1, offset=5, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            self.device.click(GET_ITEMS_1)
+            self.interval_reset(BATTLE_STATUS_S)
+            self.interval_reset(BATTLE_STATUS_A)
+            self.interval_reset(BATTLE_STATUS_B)
+            return True
+        if self.appear(GET_ITEMS_2, offset=5, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            self.device.click(GET_ITEMS_1)
+            self.interval_reset(BATTLE_STATUS_S)
+            self.interval_reset(BATTLE_STATUS_A)
+            self.interval_reset(BATTLE_STATUS_B)
+            return True
+        if self.appear(GET_ITEMS_3, offset=5, interval=self.battle_status_click_interval):
+            if drop:
+                drop.handle_add(self)
+            self.device.click(GET_ITEMS_1)
+            self.interval_reset(BATTLE_STATUS_S)
+            self.interval_reset(BATTLE_STATUS_A)
+            self.interval_reset(BATTLE_STATUS_B)
+            return True
+
+        return False
+
+    def handle_exp_info(self):
+        """
+        Returns:
+            bool:
+        """
+        if self.is_combat_executing():
+            return False
+        if self.appear_then_click(EXP_INFO_S):
+            self.device.sleep((0.25, 0.5))
+            return True
+        if self.appear_then_click(EXP_INFO_A):
+            self.device.sleep((0.25, 0.5))
+            return True
+        if self.appear_then_click(EXP_INFO_B):
+            self.device.sleep((0.25, 0.5))
+            return True
+
+        return False
+
+    def handle_get_ship(self, drop=None):
+        """
+        Args:
+            drop (DropImage):
+
+        Returns:
+            bool:
+        """
+        if self.appear_then_click(GET_SHIP, interval=1):
+            if self.appear(NEW_SHIP):
+                logger.info('Get a new SHIP')
+                if drop:
+                    drop.handle_add(self)
+                self.config.GET_SHIP_TRIGGERED = True
+            return True
+
+        return False
+
+    def handle_combat_mis_click(self):
+        """
+        Returns:
+            bool:
+        """
+        if self.appear(MUNITIONS_CHECK, offset=(20, 20), interval=5):
+            logger.info(f'{MUNITIONS_CHECK} -> {BACK_ARROW}')
+            self.device.click(BACK_ARROW)
+            return True
+        if self.appear(EXERCISE_CHECK, offset=(20, 20), interval=5):
+            logger.info(f'{EXERCISE_CHECK} -> {BACK_ARROW}')
+            self.device.click(BACK_ARROW)
+            return True
+
+        return False

--- a/module/combat_ui/dictionary.py
+++ b/module/combat_ui/dictionary.py
@@ -1,0 +1,31 @@
+from module.combat.assets import *
+from module.combat_ui.assets import *
+
+pause_template = {
+    "Old": PAUSE,
+    "New": PAUSE_New,
+    "Iridescent_Fantasy": PAUSE_Iridescent_Fantasy,
+    "Christmas": PAUSE_Christmas,
+    "Cyber": PAUSE_Cyber,
+    "Neon": PAUSE_Neon,
+    "HolyLight": PAUSE_HolyLight,
+}
+
+quit_template = {
+    "Old": QUIT,
+    "New": QUIT_New,
+    "Iridescent_Fantasy": QUIT_Iridescent_Fantasy,
+    "Christmas": QUIT_Christmas,
+    "Cyber": QUIT_New,  # Battle UI PAUSE_Cyber uses QUIT_New
+    "Neon": QUIT_New,  # Battle UI PAUSE_Neon uses QUIT_New
+    "HolyLight": QUIT_New,  # Battle UI PAUSE_HolyLight uses QUIT_New
+}
+
+# combat_manual_template = {
+# }
+
+# combat_auto_template = {
+# }
+
+# submarine_template = {
+# }


### PR DESCRIPTION
分离了Combat类中所有仅涉及页面识别和点击的函数，新建CombatUI类作为Combat的基类之一；
CombatUI类中内置theme属性用于缓存当前战斗的UI类别，便于后续pr中进一步判断COMBAT_AUTO、SUBMARINE_AVAILABLE等与战斗UI相关的按钮。

已在本地通过旧UI和新默认UI的测试。

is_combat_loading()针对截图的缓存留给后续pr，本pr暂不处理。