### PR TITLE
Opt: delay cl1 before os_explore finishes

### DIFF
--- a/module/os/operation_siren.py
+++ b/module/os/operation_siren.py
@@ -467,7 +467,7 @@ class OperationSiren(OSMap):
         with self.config.multi_set():
             next_run = self.config.Scheduler_NextRun
             for task in ['OpsiObscure', 'OpsiAbyssal', 'OpsiArchive', 'OpsiStronghold', 'OpsiMeowfficerFarming',
-                         'OpsiMonthBoss', 'OpsiShop']:
+                         'OpsiMonthBoss', 'OpsiShop', 'OpsiHazard1Leveling']:
                 keys = f'{task}.Scheduler.NextRun'
                 current = self.config.cross_get(keys=keys, default=DEFAULT_TIME)
                 if current < next_run:


### PR DESCRIPTION
侵蚀一应该也是消耗ap的任务，不应该跟开荒抢ap？
如果不做请直接关闭