### PR TITLE
Fix: vanguard_change logic

### DIFF
--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -273,18 +273,12 @@ class GemsFarming(CampaignRun, FleetEquipment, Dock):
             max_level = 70
 
         scanner = ShipScanner(level=(max_level, max_level), emotion=(10, 150),
-                              fleet=self.fleet_to_attack, status='free')
+                              fleet=[0, self.fleet_to_attack], status='free')
         scanner.disable('rarity')
 
-        ships = scanner.scan(self.device.image)
-        if ships:
-            # Don't need to change current
-            return ships
-
-        scanner.set_limitation(fleet=0)
         if self.config.GemsFarming_CommonDD in ['any', 'favourite', 'z20_or_z21']:
             # Change to any ship
-            return scanner.scan(self.device.image, output=False)
+            return scanner.scan(self.device.image)
 
         candidates = self.find_candidates(self.get_templates(self.config.GemsFarming_CommonDD), scanner)
         if candidates:

--- a/module/retire/scanner.py
+++ b/module/retire/scanner.py
@@ -64,6 +64,10 @@ class Ship:
                 elif isinstance(value, tuple):
                     if not (value[0] <= self.__dict__[key] <= value[1]):
                         return False
+                # list means should be in the list
+                elif isinstance(value, list):
+                    if self.__dict__[key] not in value:
+                        return False
 
         return True
 
@@ -384,6 +388,8 @@ class ShipScanner(Scanner):
             lower = self.sub_scanners[key].limit_value(lower)
             upper = self.sub_scanners[key].limit_value(upper)
             self.limitaion[key] = (lower, upper)
+        elif isinstance(value, list):
+            self.limitaion[key] = [self.sub_scanners[key].limit_value(v) for v in value]
         else:
             self.limitaion[key] = self.sub_scanners[key].limit_value(value)
 


### PR DESCRIPTION
激进地换前排并不会导致船坞溢出，还能减少因为前排没心情造成的换船次数。
加上目前换不换船都得先拆装备，不存在时间差距，所以应当激进地替换前排为当前心情值最高的可用前排。