### PR TITLE
Fix: [FPY] 我要保证我见到lme的时候AlasFpyBridge是可用的!

### DIFF
--- a/submodule/AlasFpyBridge/fpy.py
+++ b/submodule/AlasFpyBridge/fpy.py
@@ -44,7 +44,8 @@ class FgoAutoScript(AzurLaneAutoScript):
         app = FGOpy(
             self.config.FpyEmulator_LaunchPath,
             {
-                "Special Drop": "FpyLimit_SpecialDrop",
+                "Special Drop": lambda:
+                    setattr(self.config, "FpyLimit_SpecialDrop", max(0, getattr(self.config, "FpyLimit_SpecialDrop") - 1)),
             },
         )
         assert app.run("ping")

--- a/submodule/AlasFpyBridge/module/FGOpy.py
+++ b/submodule/AlasFpyBridge/module/FGOpy.py
@@ -63,9 +63,7 @@ class FGOpy(HeadlessCliApplication):
             return
         prompt, datetime, level, module, content = match.groups()
         getattr(logger, level.lower())(content)
-        item = self.counter.get(content)
-        if item:
-            setattr(self.config, item, getattr(self.config, item) - 1)
+        self.counter.get(content, lambda: None)()
 
         if self.first_log:
             self.first_log = False

--- a/submodule/AlasFpyBridge/module/config/argument/args.json
+++ b/submodule/AlasFpyBridge/module/config/argument/args.json
@@ -83,7 +83,7 @@
       "Interval": {
         "type": "input",
         "value": "00:05",
-        "validate": "\\d+:\\d"
+        "validate": "\\d+:\\d+"
       }
     },
     "Storage": {
@@ -176,7 +176,7 @@
       "Interval": {
         "type": "input",
         "value": "07:00",
-        "validate": "\\d+:\\d"
+        "validate": "\\d+:\\d+"
       }
     },
     "Storage": {

--- a/submodule/AlasFpyBridge/module/config/argument/argument.yaml
+++ b/submodule/AlasFpyBridge/module/config/argument/argument.yaml
@@ -44,7 +44,7 @@ FpyEmulator:
 FpyInterval:
   Interval:
     value: 07:00
-    validate: "\\d+:\\d"
+    validate: "\\d+:\\d+"
 
 FpyTeam:
   Index:

--- a/submodule/AlasFpyBridge/module/config/i18n/en-US.json
+++ b/submodule/AlasFpyBridge/module/config/i18n/en-US.json
@@ -20,7 +20,7 @@
   "Task": {
     "Fpy": {
       "name": "FGO-py",
-      "help": "Requries FGO-py v11.2.0 or higher"
+      "help": "Requries FGO-py v20.1.2 or higher"
     },
     "FpyHeartbeat": {
       "name": "Heartbeat",

--- a/submodule/AlasFpyBridge/module/config/i18n/ja-JP.json
+++ b/submodule/AlasFpyBridge/module/config/i18n/ja-JP.json
@@ -20,7 +20,7 @@
   "Task": {
     "Fpy": {
       "name": "FGO-py設定",
-      "help": "FGO-py v11.2.0以降が必要です"
+      "help": "FGO-py v20.1.2以降が必要です"
     },
     "FpyHeartbeat": {
       "name": "心拍",

--- a/submodule/AlasFpyBridge/module/config/i18n/zh-CN.json
+++ b/submodule/AlasFpyBridge/module/config/i18n/zh-CN.json
@@ -20,7 +20,7 @@
   "Task": {
     "Fpy": {
       "name": "FGO-py设置",
-      "help": "需要FGO-py v11.2.0或更高"
+      "help": "需要FGO-py v20.1.2或更高"
     },
     "FpyHeartbeat": {
       "name": "心跳",

--- a/submodule/AlasFpyBridge/module/utils/headlessCliApplication.py
+++ b/submodule/AlasFpyBridge/module/utils/headlessCliApplication.py
@@ -9,7 +9,7 @@ class HeadlessCliApplication:
     """Wrap a cli application to provide programmable interactive access"""
 
     def __init__(self, launch):
-        self.pipe = Popen([launch], stdin=PIPE, stdout=PIPE, stderr=STDOUT, text=True)
+        self.pipe = Popen([launch], stdin=PIPE, stdout=PIPE, stderr=STDOUT, encoding="utf-8", text=True)
 
         def f():
             while True:


### PR DESCRIPTION
今天梦中惊醒,忽然想起去年7月15日我向FGO-py中引入[PEP 540](https://peps.python.org/pep-0540)导致的AlasFpyBridge完全无法使用的问题仍然没有得到修复!这是非常糟糕的!所以我向相关源码中添加了18个字节以修复此问题!

简单来说,PEP540会将python默认的编码从locale()改成utf-8,以前需要手动写encoding='utf-8'的地方都不用写了(正好我经常忘记写),在PIPE中输出时的字节流也是utf-8的,这使得在阿拉善这边需要指定编码,*我们先进的磁能坦克已经完全超越了老旧的天启坦克*

与此同时,也修复了(自2023年6月起就存在但是由于一个在FGO-py本体中做了walkaround另一个可以不经过ui直接改配置文件的原因显得一点都不紧急而躺在我的硬盘中许久但迟迟没有推送的) 1.特殊掉落计数更新时访问不存在的成员 与 2.时间间隔正则表达式 的两个错误

关于我2023年5月(或更早?)就承诺过的*在Alas中完成FGO的每周任务,使得用户的干预从每周一次降低到每个服务器维护一次*的美好愿景将在我回到日本拥有良好的网络连接后进行开发