### PR TITLE
Upd: ocr params for get_zone_name in JP server

### DIFF
--- a/module/os/map_operation.py
+++ b/module/os/map_operation.py
@@ -77,7 +77,7 @@ class OSMapOperation(MapOrderHandler, MissionHandler, PortHandler, StorageHandle
     @Config.when(SERVER='jp')
     def get_zone_name(self):
         # For JP only
-        ocr = Ocr(MAP_NAME, lang='jp', letter=(201, 218, 239), threshold=220, name='OCR_OS_MAP_NAME')
+        ocr = Ocr(MAP_NAME, lang='jp', letter=(157, 173, 192), threshold=127, name='OCR_OS_MAP_NAME')
         name = ocr.ocr(self.device.image)
         self.is_zone_name_hidden = '安全' in name
         # Remove punctuations


### PR DESCRIPTION
这个rgb的调参是按以前有问题的图片在threshold=127情况下全部正确的rgb算聚类算出来的。至于为什么这种黑边灰中心的字体能通过测试我也不理解。

目前经过短猫3海域绕两圈的测试，没发现问题。

一些图片的处理效果：
![1742778249136901](https://github.com/user-attachments/assets/c8b75aa5-a9fa-4130-b23a-29599a5742c8)
![1742778249814477](https://github.com/user-attachments/assets/6d245922-e903-4f64-b900-11fa07167641)
![1742778249901205](https://github.com/user-attachments/assets/0cbb189d-522d-4ee1-9aa0-0e55c2d9c1e1)
![1742778249984512](https://github.com/user-attachments/assets/f2b96e3d-2d29-411a-b92e-3db38ca547ed)
![1742778250229313](https://github.com/user-attachments/assets/c4f88261-d11d-42c0-b428-41f8893eb4dc)
![1742778250308840](https://github.com/user-attachments/assets/c5c935da-e7b1-4684-8aa1-17222c608d66)
![1742778250395507](https://github.com/user-attachments/assets/a40ad8ac-58a6-4c96-a086-ef9a19c54eaf)
![1742778250468583](https://github.com/user-attachments/assets/89f359b4-0fb6-4a18-a5cf-36d1c322dc95)
![1742778250544347](https://github.com/user-attachments/assets/4d8d3b4c-9ea4-43f9-965c-ae55953dca1e)
![1742778250609553](https://github.com/user-attachments/assets/fb240a2e-bc6e-4326-a5ba-5215c122a865)
