### PR TITLE
Fix: urgent commission undetected

### DIFF
--- a/module/commission/commission.py
+++ b/module/commission/commission.py
@@ -208,8 +208,6 @@ class RewardCommission(UI, InfoHandler):
             # which causes the topmost one undetected.
             if not COMMISSION_SCROLL.appear(main=self) or COMMISSION_SCROLL.cal_position(main=self) < 0.05 or COMMISSION_SCROLL.length / COMMISSION_SCROLL.total > 0.98:
                 pre_peaks = lines_detect(self.device.image)
-                if not len(pre_peaks):
-                    return True
                 self.device.screenshot()
                 while 1:
                     peaks = lines_detect(self.device.image)


### PR DESCRIPTION
#1626 在_commission_ensure_mode函数中加入了pre_peaks，但是循环前的那一处判断可能提前返回True（在紧急委托数量不足一页时），此时委托界面图像并未完全停止，导致扫描不到紧急委托，从而在委托已经做满的情况下继续尝试做委托。

修改前：
最下方commission detect没有扫到紧急委托
![QQ图片20250525170927](https://github.com/user-attachments/assets/d5985378-0436-41ef-9f02-62b16564a919)

修改后：
![QQ图片20250525170948](https://github.com/user-attachments/assets/fd1aa840-9a2b-4345-989c-3bc7c763fdbe)
