### PR TITLE
Add requirements_generator.py and requirements.txt for alas-launcher (launcher2)

### DIFF
--- a/deploy/launcher2/requirements.txt
+++ b/deploy/launcher2/requirements.txt
@@ -1,0 +1,43 @@
+# Image processing
+numpy==1.21.6
+scipy==1.8.1
+pillow
+opencv-python-headless==4.11.0.86
+imageio==2.27.0
+
+# Device connection
+adbutils==0.11.0
+uiautomator2==2.16.17
+uiautomator2cache==0.3.0.1
+wrapt==1.15.0
+retrying
+lz4
+av==10.0.0
+psutil==5.9.3
+
+# Utils
+rich==11.2.0
+tqdm
+jellyfish==0.11.2
+pyyaml
+inflection
+pydantic
+aiofiles
+prettytable==2.2.1
+anyio==1.3.1
+
+# Pushing
+onepush==1.4.0
+pycryptodome==3.9.9
+pypresence==4.2.1
+
+# Ocr
+cnocr==1.2.3.1
+mxnet==1.6.99
+
+# Webui
+pywebio==1.6.2
+starlette==0.14.2
+uvicorn[standard]==0.17.6
+zerorpc==0.6.3
+pyzmq==23.2.1

--- a/deploy/launcher2/requirements_generator.py
+++ b/deploy/launcher2/requirements_generator.py
@@ -1,0 +1,69 @@
+import os
+
+from deploy.logger import logger
+
+BASE_FOLDER = os.path.dirname(os.path.abspath(__file__))
+logger.info(BASE_FOLDER)
+
+
+def read_file(file):
+    out = {}
+    with open(file, 'r', encoding='utf-8') as f:
+        for line in f.readlines():
+            if not line.strip():
+                continue
+            res = [s.strip() for s in line.split('==')]
+            if len(res) > 1:
+                name, version = res
+            else:
+                name, version = res[0], None
+            out[name] = version
+
+    return out
+
+
+def write_file(file, data):
+    lines = []
+    for name, version in data.items():
+        if version:
+            lines.append(f'{name}=={version}')
+        else:
+            lines.append(str(name))
+
+    with open(file, 'w', encoding='utf-8', newline='') as f:
+        text = '\n'.join(lines)
+        text = text.replace('#', '\n#').strip()
+        f.write(text)
+
+
+def launcher2_requirements_generate(requirements_in='requirements-in.txt'):
+    requirements = read_file(requirements_in)
+
+    logger.info(f'Generate requirements for launcher2 environment')
+    lock = {
+        'numpy': '1.21.6',
+        'scipy': '1.8.1',
+        'opencv-python': {
+            'name': 'opencv-python-headless',
+            'version': '4.11.0.86',
+        },
+        'wrapt': '1.15.0',
+        'cnocr': '1.2.3.1',
+        'mxnet': '1.6.99',  # Modified version which does not actually exist
+        'pyzmq': '23.2.1',
+    }
+    new = {}
+    logger.info(requirements)
+    for name, version in requirements.items():
+        if name == 'alas-webapp':
+            continue
+        if name in lock:
+            version = lock[name] if not isinstance(lock[name], dict) else lock[name]['version']
+            name = name if not isinstance(lock[name], dict) else lock[name]['name']
+        new[name] = version
+
+    write_file(os.path.join(BASE_FOLDER, f'./requirements.txt'), data=new)
+
+
+if __name__ == '__main__':
+    launcher2_requirements_generate()

--- a/dev_tools/requirements_updater.py
+++ b/dev_tools/requirements_updater.py
@@ -3,6 +3,7 @@ import os
 from deploy.AidLux.requirements_generator import aidlux_requirements_generate
 from deploy.docker.requirements_generator import docker_requirements_generate
 from deploy.headless.requirements_generator import headless_requirements_generate
+from deploy.launcher2.requirements_generator import launcher2_requirements_generate
 
 # Ensure running in Alas root folder
 os.chdir(os.path.join(os.path.dirname(__file__), '../'))
@@ -41,3 +42,4 @@ if __name__ == '__main__':
     aidlux_requirements_generate()
     docker_requirements_generate()
     headless_requirements_generate()
+    launcher2_requirements_generate()


### PR DESCRIPTION
The repo is located at https://github.com/swordfeng/alas-launcher 这是一个专门给全平台自动化打包的版本，启动器会自动根据打包设置环境变量，同时单独提供了一个浏览器套壳。（代码其实就一个文件）

因为 mxnet 兼容性问题，打包的时候是把 mxnet 1.9.1 版本强行改为 1.6.99 才能把所有 wheel 装到一起。
mxnet 和 cnocr v1 都不再更新了，所以应该不用太担忧升级问题。