### PR TITLE
Feature: Add 121 strategy for 15-4 | 给15-4添加121策略

### DIFF
--- a/campaign/campaign_main/campaign_15_4_121.py
+++ b/campaign/campaign_main/campaign_15_4_121.py
@@ -1,49 +1,12 @@
-from module.logger import logger
-from module.map.map_base import CampaignMap
-from module.map.map_grids import SelectedGrids, RoadGrids
+import copy
 
-from .campaign_15_base import CampaignBase, W15GridInfo
-from .campaign_15_base import Config as ConfigBase
+# Do not remove the Config import. It's inherited from 15-4 and needs to be exported.
+from .campaign_15_4 import Config # noqa # pylint: disable=unused-import
+from .campaign_15_4 import MAP as MAP_15_4, Campaign as Campaign_15_4 
 
-MAP = CampaignMap('15-4-121')
-MAP.grid_class = W15GridInfo
-MAP.shape = 'K9'
-MAP.camera_data = ['C2', 'C5', 'C7', 'F2', 'F5', 'F7', 'H2', 'H5', 'H7']
-MAP.camera_data_spawn_point = ['H2']
-MAP.camera_sight = (-2, -1, 3, 2)
-MAP.map_data = """
-    Me -- ME ME Me -- ME ++ ++ ME ME
-    ME -- -- -- -- ME -- ++ ++ -- ME
-    ++ -- -- MS -- -- ME SP SP ME Me
-    ++ ME -- ++ ++ -- -- -- -- ME --
-    -- Me ME MA ++ ME -- MS -- -- ME
-    ME ME ME -- -- -- -- ++ ME -- Me
-    ME -- __ -- ME ME -- ME ME -- ++
-    -- -- ++ -- Me -- ME ME ME Me ME
-    MB Me -- ME ME Me ++ ++ ++ -- Me
-"""
-MAP.weight_data = """
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-    50 50 50 50 50 50 50 50 50 50 50
-"""
-MAP.spawn_data = [
-    {'battle': 0, 'enemy': 8},
-    {'battle': 1, 'enemy': 1},
-    {'battle': 2, 'enemy': 1},
-    {'battle': 3, 'enemy': 1, 'siren': 1},
-    {'battle': 4, 'enemy': 2},
-    {'battle': 5},
-    {'battle': 6, 'siren': 1},
-    {'battle': 7, 'enemy': 1},
-    {'battle': 8, 'boss': 1},
-]
+MAP = copy.copy(MAP_15_4)
+MAP.name = '15-4-121'
+
 A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, \
 A2, B2, C2, D2, E2, F2, G2, H2, I2, J2, K2, \
 A3, B3, C3, D3, E3, F3, G3, H3, I3, J3, K3, \
@@ -55,40 +18,8 @@ A8, B8, C8, D8, E8, F8, G8, H8, I8, J8, K8, \
 A9, B9, C9, D9, E9, F9, G9, H9, I9, J9, K9, \
     = MAP.flatten()
 
-
-class Config(ConfigBase):
-    # ===== Start of generated config =====
-    # MAP_SIREN_TEMPLATE = ['BOSS']
-    # MOVABLE_ENEMY_TURN = (2,)
-    # MAP_HAS_SIREN = True
-    # MAP_HAS_MOVABLE_ENEMY = True
-    MAP_HAS_MAP_STORY = False
-    MAP_HAS_FLEET_STEP = False
-    MAP_HAS_AMBUSH = True
-    # MAP_HAS_MYSTERY = True
-    # ===== End of generated config =====
-
-    MAP_SWIPE_MULTIPLY = (1.055, 1.075)
-    MAP_SWIPE_MULTIPLY_MINITOUCH = (1.020, 1.039)
-    MAP_SWIPE_MULTIPLY_MAATOUCH = (0.990, 1.008)
-
-
-class Campaign(CampaignBase):
+class Campaign(Campaign_15_4):
     MAP = MAP
-
-    def battle_function(self):
-        if not self.config.MAP_CLEAR_ALL_THIS_TIME:
-            return super().battle_function()
-
-        if self.battle_count in [3, 6] \
-                or (self.battle_count in [0, 1] and not self.map_is_clear_mode):
-            func = self.FUNCTION_NAME_BASE + str(self.battle_count)
-            logger.info(f'Using function: {func}')
-            func = self.__getattribute__(func)
-            result = func()
-            return result
-
-        return super().battle_function()
 
     def battle_0(self):
         if not self.map_is_clear_mode and self.map_has_mob_move:


### PR DESCRIPTION
Some new tutorials use the 1-2-1 strategy for 15-4, consisting of an overpowered fleet that handles all enemies and Boss 1 and 3. The secondary fleet handles Boss 2 only.

Thanks to the slicing in the following lines, adding a suffix to the main campaign map file name does not interfere with the level name extraction. Therefore, it's possible to add a new, hypothetical level `15-4-121` that executes the 1-2-1 strategy on 15-4. https://github.com/LmeSzinc/AzurLaneAutoScript/blob/cbba8f024a69c24380efe82b3b0ec3c736d01dfb/module/campaign/run.py#L43-L44

This PR allows the user to enter `15-4-121` as the level name and run 121 strategy on 15-4.

This is a sketchy and dirty patch, but cleaner than adding yet more parameters to the config just for 15-4 (and -3).

Tested in CN server clear mode and non-clear mode ONLY. Did not test CLEAR_ALL mode.

----------------------
有些新的15图教程使用了121策略，用一个动力强劲的一队解决所有敌人以及Boss 1,3，而二队仅解决Boss2。

因为这段主线关卡名检索逻辑，在文件名后面加后缀不会影响关卡名的检测，也就是说可以定义一个虚拟的`15-4-121`关卡，来在15-4图上跑121策略。
https://github.com/LmeSzinc/AzurLaneAutoScript/blob/cbba8f024a69c24380efe82b3b0ec3c736d01dfb/module/campaign/run.py#L43-L44

这个PR能让用户在主线图中任务中使用`15-4-121`作为关卡名称，使用121逻辑刷15-4。

这个解决方法有点潦草，但感觉比在设置界面里加个专门为15-4（和-3）的选项要简洁一点。

仅在CN服务器测试过周回以及非周回模式，暂未测试全清模式。