### PR TITLE
Fix: Can't get oil amount after win/retreat

### DIFF
--- a/module/campaign/campaign_status.py
+++ b/module/campaign/campaign_status.py
@@ -117,6 +117,11 @@ class CampaignStatus(UI):
 
             if timeout.reached():
                 logger.warning('Get oil timeout')
+                # Return to main and come back
+                self.ui_goto_main()
+                from module.campaign.run import CampaignRun
+                CampaignRun(config=self.config, device=self.device).run(
+                    name=self.config.Campaign_Name, folder=self.config.Campaign_Event, mode=self.config.Campaign_Mode)
                 break
 
             if not self.appear(OCR_OIL_CHECK, offset=(10, 2)):


### PR DESCRIPTION
无法识别油量时回到主界面再返回
Go to the main page and come back after alas can't get the oil icon
https://github.com/LmeSzinc/AzurLaneAutoScript/issues/5163