### PR TITLE
Fix: Can't get oil amount for TW server

### DIFF
--- a/module/coalition/coalition.py
+++ b/module/coalition/coalition.py
@@ -153,7 +153,7 @@ class Coalition(CoalitionCombat, CampaignEvent):
             if self.config.SERVER in ['tw']:
 	            self.ui_goto_main()
 	            self.ui_goto(page_campaign_menu)
-	                if self.triggered_stop_condition(oil_check=True):
+	            if self.triggered_stop_condition(oil_check=True):
 		            break
             self.device.stuck_record_clear()
             self.device.click_record_clear()


### PR DESCRIPTION
跳過常態檢測，嘗試在進入活動前獲取油量，仍待測試