### PR TITLE
Fix: Can't get oil amount for TW server

### DIFF
--- a/module/coalition/coalition.py
+++ b/module/coalition/coalition.py
@@ -151,7 +151,6 @@ class Coalition(CoalitionCombat, CampaignEvent):
 
             # UI switches
             if self.config.SERVER in ['tw']:
-	            self.ui_goto_main()
 	            self.ui_goto(page_campaign_menu)
 	            if self.triggered_stop_condition(oil_check=True):
 		            break


### PR DESCRIPTION
跳過常態檢測，嘗試在進入活動前獲取油量，~~仍待測試~~，已於本地環境測試，符合預期功能
fix #5214 