### PR TITLE
Fix: handle manjuu gif in Fleet._goto()

### DIFF
--- a/module/map/fleet.py
+++ b/module/map/fleet.py
@@ -375,6 +375,11 @@ class Fleet(Camera, AmbushHandler):
                     walk_timeout.reset()
                     continue
 
+                # Manjuu gif
+                if self.handle_manjuu():
+                    walk_timeout.reset()
+                    continue
+
                 if self.handle_walk_out_of_step():
                     raise MapWalkError('walk_out_of_step')
 


### PR DESCRIPTION
bug，如果到达海图后弹出黄鸡，时间超过timer，则会尝试导致重新开始扫描，但此后若触发加载画面，则会导致not_in_map报错，alas停机。
修改已经过实际测试。

原始问题log：
[log.txt](https://github.com/user-attachments/files/22985537/log.txt)

<details><summary>错误截图预览</summary>

![8F6XPZ25(2P{H86DICBC1YJ](https://github.com/user-attachments/assets/23678d6c-68b9-4442-81ad-d186918c3469)
<img width="2134" height="1429" alt="G }Y37QIRN%ZC1K@UX5JHHU" src="https://github.com/user-attachments/assets/d74f5762-99de-4fee-8b01-624ec471ec3b" />
</details>