### PR TITLE
Add: Configurable restart delay in Error settings

### DIFF
--- a/alas.py
+++ b/alas.py
@@ -77,10 +77,10 @@ class AzurLaneAutoScript:
         except (GameStuckError, GameTooManyClickError) as e:
             logger.error(e)
             self.save_error_log()
-            logger.warning(f'Game stuck, {self.device.package} will be restarted in 10 seconds')
+            logger.warning(f'Game stuck, {self.device.package} will be restarted in {self.config.Error_RestartDelay} seconds')
             logger.warning('If you are playing by hand, please stop Alas')
             self.config.task_call('Restart')
-            self.device.sleep(10)
+            self.device.sleep(self.config.Error_RestartDelay)
             return False
         except GameBugError as e:
             logger.warning(e)
@@ -88,7 +88,7 @@ class AzurLaneAutoScript:
             logger.warning('An error has occurred in Azur Lane game client, Alas is unable to handle')
             logger.warning(f'Restarting {self.device.package} to fix it')
             self.config.task_call('Restart')
-            self.device.sleep(10)
+            self.device.sleep(self.config.Error_RestartDelay)
             return False
         except GamePageUnknownError:
             logger.info('Game server may be under maintenance or network may be broken, check server status now')

--- a/config/template.json
+++ b/config/template.json
@@ -18,7 +18,8 @@
       "HandleError": true,
       "SaveError": true,
       "OnePushConfig": "provider: null",
-      "ScreenshotLength": 1
+      "ScreenshotLength": 1,
+      "RestartDelay": 10
     },
     "Optimization": {
       "ScreenshotInterval": 0.3,

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -193,6 +193,10 @@
       "ScreenshotLength": {
         "type": "input",
         "value": 1
+      },
+      "RestartDelay": {
+        "type": "input",
+        "value": 10
       }
     },
     "Optimization": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -88,6 +88,7 @@ Error:
     mode: yaml
     value: 'provider: null'
   ScreenshotLength: 1
+  RestartDelay: 10
 Optimization:
   ScreenshotInterval: 0.3
   CombatScreenshotInterval: 1.0

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -36,6 +36,7 @@ class GeneratedConfig:
     Error_SaveError = True
     Error_OnePushConfig = 'provider: null'
     Error_ScreenshotLength = 1
+    Error_RestartDelay = 10
 
     # Group `Optimization`
     Optimization_ScreenshotInterval = 0.3

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -504,6 +504,10 @@
     "ScreenshotLength": {
       "name": "Record Screenshot(s)",
       "help": "Number of screenshots saved when exception occurs"
+    },
+    "RestartDelay": {
+      "name": "Restart Delay (seconds)",
+      "help": "How long to wait before restarting after a crash or stuck"
     }
   },
   "Optimization": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -504,6 +504,10 @@
     "ScreenshotLength": {
       "name": "Error.ScreenshotLength.name",
       "help": "Error.ScreenshotLength.help"
+    },
+    "RestartDelay": {
+      "name": "Error.RestartDelay.name",
+      "help": "Error.RestartDelay.help"
     }
   },
   "Optimization": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -504,6 +504,10 @@
     "ScreenshotLength": {
       "name": "出错时，保留最后 X 张截图",
       "help": ""
+    },
+    "RestartDelay": {
+      "name": "重启等待时间（秒）",
+      "help": "游戏卡死或崩溃后，等待多少秒再重启"
     }
   },
   "Optimization": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -504,6 +504,10 @@
     "ScreenshotLength": {
       "name": "出錯時，保留最後 X 張截圖",
       "help": ""
+    },
+    "RestartDelay": {
+      "name": "重啟等待時間（秒）",
+      "help": "遊戲當機或崩潰後，等待多少秒再重啟"
     }
   },
   "Optimization": {


### PR DESCRIPTION
Add a new config option `RestartDelay` in Error settings group.

The restart delay after game stuck or crash was hardcoded to 10 seconds.
Users can now customize this value based on their network and device conditions.

这是我第一次提交 PR，如有不足请多指正。

增加此功能的原因：在网络波动或设备较慢的情况下，游戏卡死后10秒内可能还未完全退出，
立即重启可能导致启动失败。允许用户自定义等待时间可以提高重启成功率（默认还是原来的10s）。
（我自己用Alas时偶尔会报错，游戏界面卡在委托任务，还有Alas经常在0点多时报错，但都只要手动启动就又好了，所以我希望通过用户根据自己情况自定义重启间隔来解决）