### PR TITLE
Fix: story option detection

### DIFF
--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -345,6 +345,7 @@ class InfoHandler(ModuleBase):
         story_option_color = (247, 247, 247)
 
         image = color_similarity_2d(self.image_crop(story_detect_area, copy=False), color=story_option_color)
+        cv2.morphologyEx(image, cv2.MORPH_CLOSE, kernel=np.ones((5, 5), dtype=np.uint8), dst=image)
         line = cv2.reduce(image, 1, cv2.REDUCE_AVG).flatten()
         line[line < 200] = 0
         line[line >= 200] = 255


### PR DESCRIPTION
不理解原来为什么用cv2.REDUCE_AVG，但是这里出问题了。

<img width="1280" height="720" alt="2026-05-16_00-06-17-844555" src="https://github.com/user-attachments/assets/7a156cf0-d143-4894-a847-6d6993deb7ca" />

截断：<img width="25" height="420" alt="detect" src="https://github.com/user-attachments/assets/355fdc7f-ccfd-4aab-b320-2f4473338215" />AVG：<img width="1" height="420" alt="line_old" src="https://github.com/user-attachments/assets/33c3b217-30a6-46c1-b4b8-111faaf6e694" />MAX：<img width="1" height="420" alt="line" src="https://github.com/user-attachments/assets/1fc6704c-34ad-4485-91ec-9277132a94a0" />

[1778861180725.zip](https://github.com/user-attachments/files/27809609/1778861180725.zip)
