### PR TITLE
连接a图和b图

### DIFF
--- a/module/config/config_manual.py
+++ b/module/config/config_manual.py
@@ -121,7 +121,7 @@ class ManualConfig:
     MAP_CHAPTER_SWITCH_20241219_SPEX = False
     # Since event_20241219_cn chapter B unlocks event startup
     # which means chapter AB are continuous
-    STAGE_INCREASE_AB = False
+    STAGE_INCREASE_AB = True
     # Insert anything to STAGE_INCREASE
     STAGE_INCREASE_CUSTOM = ''
     MAP_HAS_CLEAR_PERCENTAGE = True

--- a/module/handler/fast_forward.py
+++ b/module/handler/fast_forward.py
@@ -372,8 +372,7 @@ class FastForwardHandler(AutoSearchHandler):
         # Insert custom increase logic
         if self.config.STAGE_INCREASE_AB:
             stage_increase = [
-                'A1 > A2 > A3 > B1 > B2 > B3',
-                'C1 > C2 > C3 > D1 > D2 > D3',
+                'A1 > A2 > A3 > B1 > B2 > B3',                
             ] + stage_increase
         custom = self.config.STAGE_INCREASE_CUSTOM
         if custom:


### PR DESCRIPTION
将活动图开荒的a1到b3连接起来。因为c图和d图需要选船，不适合连接，所以分开处理