### PR TITLE
Fix: 优化低心情处理与活动困难图编队流程

### DIFF
--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -24,7 +24,7 @@ SIM_VALUE = 0.92
 
 class GemsCampaignOverride(CampaignBase):
 
-    def handle_combat_low_emotion(self):
+    def handle_combat_low_emotion(self, fleet_index=None):
         """
         Overwrite info_handler.handle_combat_low_emotion()
         If change vanguard is enabled, withdraw combat and change flagship and vanguard

--- a/module/campaign/run.py
+++ b/module/campaign/run.py
@@ -15,6 +15,9 @@ from module.ui.page import page_campaign
 
 
 class CampaignRun(CampaignEvent):
+    EMOTION_DOCK_CHECK_TASKS = {'Main', 'Main2', 'Main3', 'Event', 'Event2', 'WarArchives'}
+    EMOTION_POPUP_ONLY_STAGE_PREFIX = ('ht', 'c', 'd')
+
     folder: str
     name: str
     stage: str
@@ -213,6 +216,14 @@ class CampaignRun(CampaignEvent):
             'event_20231026_cn',
             'event_20241024_cn',
             'event_20250424_cn',
+            'event_20260625_cn',
+            'event_20250724_cn',
+            'event_20250814_cn',
+            'event_20251023_cn',
+            'event_20260326_cn',
+            'war_archives_20230525_cn',
+            'war_archives_20231026_cn',
+            'war_archives_20240725_cn',
         ]:
             name = convert.get(name, name)
         # Convert between A/B/C/D and T/HT
@@ -244,6 +255,14 @@ class CampaignRun(CampaignEvent):
             'event_20241024_cn',
             'event_20241121_cn',
             'event_20250424_cn',
+            'event_20260625_cn',
+            'event_20250724_cn',
+            'event_20250814_cn',
+            'event_20251023_cn',
+            'event_20260326_cn',
+            'war_archives_20230525_cn',
+            'war_archives_20231026_cn',
+            'war_archives_20240725_cn',
         ]:
             name = convert.get(name, name)
         else:
@@ -325,6 +344,112 @@ class CampaignRun(CampaignEvent):
             self.config.task_call('Commission', force_call=True)
             self.config.task_stop('Commission notice found')
 
+    @classmethod
+    def is_event_hard_stage(cls, name, folder):
+        if not str(folder).startswith('event_'):
+            return False
+        name = str(name).lower()
+        return name.startswith(cls.EMOTION_POPUP_ONLY_STAGE_PREFIX)
+
+    def emotion_popup_only_set(self, name, folder, log=True):
+        popup_only = self.is_event_hard_stage(name=name, folder=folder)
+        self.config.Emotion_PopupOnly = popup_only
+        if hasattr(self, 'campaign'):
+            self.campaign.config.Emotion_PopupOnly = popup_only
+        if popup_only and log:
+            logger.info('Event hard stage uses popup-only emotion control')
+
+    def emotion_dock_calibrate(self):
+        """
+        Sync current task emotion ledger from normal fleet ships in dock.
+
+        Returns:
+            bool: If dock UI might have been entered and campaign UI should be restored.
+
+        Pages:
+            in: page_campaign
+            out: page_campaign or page_dock
+        """
+        command = self.config.Scheduler_Command
+        if command not in self.EMOTION_DOCK_CHECK_TASKS:
+            return False
+        if self.campaign.emotion.is_popup_only:
+            return False
+        if not self.campaign.emotion.is_calculate:
+            return False
+
+        fleet_mapping = {}
+        for task_fleet in [1, 2]:
+            normal_fleet = getattr(self.config, f'Fleet_Fleet{task_fleet}', None)
+            try:
+                normal_fleet = int(normal_fleet)
+            except (TypeError, ValueError):
+                logger.warning(f'Invalid Fleet_Fleet{task_fleet}: {normal_fleet}')
+                continue
+            if 1 <= normal_fleet <= 6:
+                fleet_mapping[task_fleet] = normal_fleet
+            else:
+                logger.warning(f'Invalid Fleet_Fleet{task_fleet}: {normal_fleet}')
+
+        if not fleet_mapping:
+            logger.warning('No normal fleet configured for emotion dock calibration')
+            return False
+
+        logger.hr('Emotion dock calibration')
+        logger.info(f'Task `{command}` fleet mapping: {fleet_mapping}')
+
+        try:
+            from module.retire.dock import Dock
+            dock = Dock(config=self.config, device=self.device)
+            scanned = dock.scan_fleet_emotion(fleet_mapping.values())
+        except Exception as e:
+            logger.warning(f'Emotion dock calibration failed, keep current ledger: {e}')
+            return True
+
+        records = {}
+        for task_fleet, normal_fleet in fleet_mapping.items():
+            value = scanned.get(normal_fleet)
+            if value is None:
+                logger.warning(
+                    f'No dock emotion result for task fleet {task_fleet} '
+                    f'(normal fleet {normal_fleet}), keep current ledger'
+                )
+                continue
+            records[f'Emotion_Fleet{task_fleet}Value'] = value
+
+        if records:
+            logger.info(f'Sync emotion ledger from dock: {records}')
+            self.config.set_record(**records)
+            campaign_records = {}
+            for arg in records:
+                record = arg.replace('Value', 'Record')
+                campaign_records[arg] = getattr(self.config, arg)
+                campaign_records[record] = getattr(self.config, record)
+            self.campaign.config.override(**campaign_records)
+            self.campaign.emotion.update()
+            self.campaign.emotion.show()
+        else:
+            logger.warning('Emotion dock calibration produced no usable records')
+
+        return True
+
+    def emotion_preflight_check(self):
+        """
+        Delay current task immediately if emotion is below threshold.
+
+        Returns:
+            bool: If current task was delayed and should leave the run loop.
+        """
+        if self.campaign.emotion.is_popup_only:
+            return False
+        try:
+            self.campaign.emotion.check_reduce(self.campaign._map_battle)
+        except ScriptEnd as e:
+            logger.hr('Script end')
+            logger.info(str(e))
+            return True
+        return False
+
     def run(self, name, folder='campaign_main', mode='normal', total=0):
         """
         Args:
@@ -335,9 +460,12 @@ class CampaignRun(CampaignEvent):
         """
         name, folder = self.handle_stage_name(name, folder, mode=mode)
         self.config.override(Campaign_Name=name, Campaign_Event=folder)
+        self.emotion_popup_only_set(name=name, folder=folder, log=False)
         self.load_campaign(name, folder=folder)
+        self.emotion_popup_only_set(name=name, folder=folder)
         self.run_count = 0
         self.run_limit = self.config.StopCondition_RunCount
+        emotion_dock_calibration_checked = False
         while 1:
             # End
             if total and self.run_count >= total:
@@ -376,6 +504,12 @@ class CampaignRun(CampaignEvent):
                 self.campaign.ensure_campaign_ui(name=self.stage, mode=mode)
             self.disable_raid_on_event()
             self.handle_commission_notice()
+            if not emotion_dock_calibration_checked:
+                emotion_dock_calibration_checked = True
+                if self.emotion_dock_calibrate():
+                    self.campaign.ensure_campaign_ui(name=self.stage, mode=mode)
+                    if self.emotion_preflight_check():
+                        break
 
             # if in hard mode, check remain times
             if self.ui_page_appear(page_campaign) and MODE_SWITCH_1.get(main=self) == 'normal':

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -362,7 +362,7 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
         Note that fleet index == 1 is mob fleet, 2 is boss fleet.
         It's not the fleet index in fleet preparation or auto search setting.
         """
-        emotion_reduce = emotion_reduce if emotion_reduce is not None else self.emotion.is_calculate
+        emotion_reduce = emotion_reduce if emotion_reduce is not None else self.emotion.should_track
 
         self.auto_search_combat_execute(emotion_reduce=emotion_reduce, fleet_index=fleet_index)
         self.auto_search_combat_status()

--- a/module/combat/combat.py
+++ b/module/combat/combat.py
@@ -202,7 +202,7 @@ class Combat(Level, HPBalancer, Retirement, SubmarineCall, CombatAuto, CombatMan
                     continue
             if self.handle_retirement():
                 continue
-            if self.handle_combat_low_emotion():
+            if self.handle_combat_low_emotion(fleet_index=fleet_index):
                 continue
             if balance_hp and self.handle_emergency_repair_use():
                 continue
@@ -596,7 +596,7 @@ class Combat(Level, HPBalancer, Retirement, SubmarineCall, CombatAuto, CombatMan
             fleet_index (int): 1 or 2
         """
         balance_hp = balance_hp if balance_hp is not None else self.config.HpControl_UseHpBalance
-        emotion_reduce = emotion_reduce if emotion_reduce is not None else self.emotion.is_calculate
+        emotion_reduce = emotion_reduce if emotion_reduce is not None else self.emotion.should_track
         if auto_mode is None:
             auto_mode = self.config.Fleet_Fleet1Mode if fleet_index == 1 else self.config.Fleet_Fleet2Mode
         if submarine_mode is None:

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -167,6 +167,14 @@ class Emotion:
     def is_ignore(self):
         return 'ignore' in self.config.Emotion_Mode
 
+    @property
+    def is_popup_only(self):
+        return getattr(self.config, 'Emotion_PopupOnly', False)
+
+    @property
+    def should_track(self):
+        return self.is_calculate and not self.is_popup_only
+
     def update(self):
         """
         Update emotion value. This should be called before doing anything.
@@ -204,6 +212,54 @@ class Emotion:
         else:
             return 2
 
+    def _fleet_indexes(self, fleet_index=None):
+        try:
+            fleet_index = int(fleet_index)
+        except (TypeError, ValueError):
+            return [1, 2]
+
+        if fleet_index in [1, 2]:
+            return [fleet_index]
+        return [1, 2]
+
+    def reset_low_emotion(self, fleet_index=None):
+        """
+        Reset emotion ledger after the game client reports low emotion.
+
+        Args:
+            fleet_index (int, None): 1 or 2. Unknown fleets reset both ledgers.
+
+        Returns:
+            list[FleetEmotion]: Fleets whose values were reset.
+        """
+        indexes = self._fleet_indexes(fleet_index=fleet_index)
+        if len(indexes) > 1:
+            logger.warning('Unable to identify low-emotion fleet, reset both fleet ledgers')
+
+        logger.hr('Emotion control')
+        self.update()
+        fleets = [self.fleets[index - 1] for index in indexes]
+        for fleet in fleets:
+            fleet.current = max(fleet.limit - 1, 0)
+            logger.info(f'Reset emotion fleet {fleet.fleet} to {fleet.current}')
+
+        self.record()
+        self.show()
+        return fleets
+
+    def delay_after_low_emotion(self, fleet_index=None):
+        """
+        Delay current task after backing out of the low-emotion sortie popup.
+
+        Raise:
+            ScriptEnd: Stop current task normally so scheduler can continue.
+        """
+        fleets = self.reset_low_emotion(fleet_index=fleet_index)
+        recovered = max([fleet.get_recovered(expected_reduce=self.reduce_per_battle) for fleet in fleets])
+        logger.info(f'Delay current task until emotion recovers at {recovered}')
+        self.config.task_delay(target=recovered)
+        raise ScriptEnd('Emotion control')
+
     def check_reduce(self, battle):
         """
         Check emotion before entering a campaign.
@@ -214,7 +270,7 @@ class Emotion:
         Raise:
             ScriptEnd: Delay current task to prevent emotion control in the future.
         """
-        if not self.is_calculate:
+        if not self.should_track:
             return
 
         method = self.config.Fleet_FleetOrder
@@ -250,6 +306,9 @@ class Emotion:
         Args:
             fleet_index (int): 1 or 2.
         """
+        if not self.should_track:
+            return
+
         self.update()
         self.record()
         self.show()
@@ -275,6 +334,9 @@ class Emotion:
         Args:
             fleet_index (int): 1 or 2.
         """
+        if not self.should_track:
+            return
+
         logger.hr('Emotion reduce')
         self.update()
 

--- a/module/event_hospital/combat.py
+++ b/module/event_hospital/combat.py
@@ -76,7 +76,7 @@ class HospitalCombat(Combat, HospitalUI, CampaignEvent):
                 check_coin()
             if self.handle_retirement():
                 continue
-            if self.handle_combat_low_emotion():
+            if self.handle_combat_low_emotion(fleet_index=fleet_index):
                 continue
             if self.appear_then_click(BATTLE_PREPARATION, offset=(30, 20), interval=2):
                 continue

--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -118,7 +118,7 @@ class InfoHandler(ModuleBase):
             return True
         if self.appear(POPUP_CANCEL_WHITE, offset=offset, interval=interval):
             POPUP_CANCEL_WHITE.name = POPUP_CANCEL_WHITE.name + '_' + name
-            self.device.click(POPUP_CONFIRM_WHITE)
+            self.device.click(POPUP_CANCEL_WHITE)
             POPUP_CANCEL_WHITE.name = POPUP_CANCEL_WHITE.name[:-len(name) - 1]
             return True
         return False
@@ -184,14 +184,22 @@ class InfoHandler(ModuleBase):
 
         return appear
 
-    def handle_combat_low_emotion(self):
-        if not self.emotion.is_ignore:
+    def handle_combat_low_emotion(self, fleet_index=None):
+        if self.emotion.is_ignore:
+            result = self.handle_popup_confirm('IGNORE_LOW_EMOTION')
+            if result:
+                # Avoid clicking AUTO_SEARCH_MAP_OPTION_OFF
+                self.interval_reset(AUTO_SEARCH_MAP_OPTION_OFF)
+            return result
+
+        if not self.emotion.is_calculate:
             return False
 
-        result = self.handle_popup_confirm('IGNORE_LOW_EMOTION')
+        result = self.handle_popup_cancel('LOW_EMOTION_CONTROL')
         if result:
             # Avoid clicking AUTO_SEARCH_MAP_OPTION_OFF
             self.interval_reset(AUTO_SEARCH_MAP_OPTION_OFF)
+            self.emotion.delay_after_low_emotion(fleet_index=fleet_index)
         return result
 
     def handle_use_data_key(self):

--- a/module/map/map.py
+++ b/module/map/map.py
@@ -26,7 +26,7 @@ class Map(Fleet):
         expected = f'combat_{expected}' if expected else 'combat'
         battle_count = self.battle_count
         self.show_fleet()
-        if self.emotion.is_calculate and self.config.Campaign_UseFleetLock:
+        if self.emotion.should_track and self.config.Campaign_UseFleetLock:
             self.emotion.wait(fleet_index=self.fleet_current_index)
         self.goto(grid, expected=expected)
 
@@ -723,7 +723,7 @@ class Map(Fleet):
         self.show_fleet()
         prev = self.battle_count
         for n, grid in enumerate(itertools.cycle(route)):
-            if self.emotion.is_calculate and self.config.Campaign_UseFleetLock:
+            if self.emotion.should_track and self.config.Campaign_UseFleetLock:
                 self.emotion.wait(fleet_index=self.fleet_current_index)
             self.goto(grid, expected='combat_nothing')
 

--- a/module/map/map_fleet_preparation.py
+++ b/module/map/map_fleet_preparation.py
@@ -175,6 +175,63 @@ class FleetOperator:
                 main.device.click(self._choose)
                 click_timer.reset()
 
+    def recommend_popup_only(self, click_count=2, confirm_attempts=3, skip_first_screenshot=True):
+        """
+        Recommend hard-mode fleet with confirmation handling.
+
+        Args:
+            click_count (int): Number of recommend clicks.
+            confirm_attempts (int): Screenshots to wait for popup confirm after each click.
+            skip_first_screenshot (bool):
+
+        Returns:
+            bool: If clicked or confirmed.
+
+        Pages:
+            in: FLEET_PREPARATION
+            out: FLEET_PREPARATION
+        """
+        main = self.main
+        clicked = False
+
+        def handle_confirm(name):
+            handled = False
+            for _ in range(confirm_attempts):
+                main.device.screenshot()
+                if main.handle_popup_confirm(name, interval=0):
+                    logger.info(f'{self}: recommend confirm handled')
+                    handled = True
+                    continue
+                if handled:
+                    break
+            return handled
+
+        for index in range(click_count):
+            if skip_first_screenshot:
+                skip_first_screenshot = False
+            else:
+                main.device.screenshot()
+
+            if main.handle_popup_confirm(f'{self}_RECOMMEND_BEFORE_{index + 1}', interval=0):
+                logger.info(f'{self}: recommend confirm handled before click')
+                clicked = True
+                main.device.screenshot()
+
+            if not self.is_hard():
+                logger.info(f'{self}: recommend button not found')
+                break
+
+            logger.info(f'{self}: click recommend {index + 1}/{click_count}')
+            main.device.click(self._advice)
+            clicked = True
+            if handle_confirm(f'{self}_RECOMMEND_{index + 1}'):
+                clicked = True
+
+        if handle_confirm(f'{self}_RECOMMEND_AFTER'):
+            clicked = True
+
+        return clicked
+
     def open(self, skip_first_screenshot=True):
         """
         Activate dropdown menu for fleet selection.
@@ -319,6 +376,19 @@ class FleetPreparation(InfoHandler):
         # Check if ship is prepared in hard mode
         h1, h2, h3 = fleet_1.is_hard_satisfied(), fleet_2.is_hard_satisfied(), submarine.is_hard_satisfied()
         logger.info(f'Hard satisfied: Fleet_1: {h1}, Fleet_2: {h2}, Submarine: {h3}')
+
+        if getattr(self.config, 'Emotion_PopupOnly', False) and any(status is not None for status in [h1, h2, h3]):
+            logger.info('HT popup-only fleet recommend')
+            if self.config.Fleet_Fleet1:
+                fleet_1.recommend_popup_only()
+            if self.config.Fleet_Fleet2:
+                fleet_2.recommend_popup_only()
+            if self.config.Submarine_Fleet:
+                submarine.recommend_popup_only()
+            self.device.screenshot()
+            h1, h2, h3 = fleet_1.is_hard_satisfied(), fleet_2.is_hard_satisfied(), submarine.is_hard_satisfied()
+            logger.info(f'Hard satisfied after recommend: Fleet_1: {h1}, Fleet_2: {h2}, Submarine: {h3}')
+
         if self.config.SERVER in ['cn', 'en', 'jp']:
             if self.config.Fleet_Fleet1:
                 fleet_1.raise_hard_not_satisfied()

--- a/module/raid/raid.py
+++ b/module/raid/raid.py
@@ -233,7 +233,7 @@ class Raid(MapOperation, RaidCombat, CampaignEvent):
                 continue
             if self.handle_retirement():
                 continue
-            if self.handle_combat_low_emotion():
+            if self.handle_combat_low_emotion(fleet_index=fleet_index):
                 continue
             if self.appear_then_click(BATTLE_PREPARATION, offset=(30, 20), interval=2):
                 continue

--- a/module/retire/dock.py
+++ b/module/retire/dock.py
@@ -204,6 +204,83 @@ class Dock(Equipment):
         self.dock_filter.set(sort=sort, index=index, faction=faction, rarity=rarity, extra=extra)
         self.dock_filter_confirm(wait_loading=wait_loading)
 
+    def scan_fleet_emotion(self, fleets, max_pages=80):
+        """
+        Scan whole dock and return minimum emotion for specified normal fleets.
+
+        Args:
+            fleets (iterable[int]): Normal in-game fleet indexes, 1 to 6.
+            max_pages (int): Safety guard against endless scroll loops.
+
+        Returns:
+            dict[int, int]: {normal_fleet_index: minimum_emotion}
+
+        Pages:
+            in: any page
+            out: page_dock
+        """
+        from module.retire.scanner import ShipScanner
+        from module.ui.page import page_dock
+
+        normalized = set()
+        for fleet in fleets:
+            try:
+                fleet = int(fleet)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= fleet <= 6:
+                normalized.add(fleet)
+        fleets = sorted(normalized)
+        if not fleets:
+            return {}
+
+        logger.hr('Dock fleet emotion scan')
+        logger.info(f'Scan normal fleets: {fleets}')
+        self.ui_goto(page_dock)
+        self.dock_favourite_set(False)
+        self.dock_sort_method_dsc_set(False)
+        self.dock_filter_set(sort='level', index='all', faction='all', rarity='all', extra='no_limit')
+
+        if DOCK_SCROLL.appear(self):
+            DOCK_SCROLL.set_top(main=self)
+            self.handle_dock_cards_loading(skip_first_screenshot=False)
+
+        scanner = ShipScanner(level=None, emotion=(0, 150), rarity=None, fleet=fleets, status=None)
+        scanner.disable('level', 'rarity', 'status')
+
+        result = {}
+        count = {fleet: 0 for fleet in fleets}
+        for page in range(1, max_pages + 1):
+            ships = scanner.scan(self.device.image, output=False)
+            page_count = 0
+            for ship in ships:
+                if ship.fleet not in count or ship.emotion is None:
+                    continue
+                count[ship.fleet] += 1
+                page_count += 1
+                previous = result.get(ship.fleet)
+                result[ship.fleet] = ship.emotion if previous is None else min(previous, ship.emotion)
+            logger.info(f'Dock scan page {page}: {page_count} target ships')
+
+            if not DOCK_SCROLL.appear(self):
+                break
+            if DOCK_SCROLL.at_bottom(self):
+                break
+            if not DOCK_SCROLL.next_page(main=self):
+                logger.warning('Dock scroll did not move, stop fleet emotion scan')
+                break
+            self.handle_dock_cards_loading(skip_first_screenshot=False)
+        else:
+            logger.warning(f'Dock fleet emotion scan reached max pages: {max_pages}')
+
+        for fleet in fleets:
+            if count[fleet]:
+                logger.attr(f'Dock emotion fleet_{fleet}', f'{result[fleet]} ({count[fleet]} ships)')
+            else:
+                logger.warning(f'No ship found in normal fleet {fleet} during dock emotion scan')
+
+        return result
+
     def dock_select_one(self, button, skip_first_screenshot=True):
         """
         Args:


### PR DESCRIPTION
## 概要

这次改动主要优化情绪控制链路，并适配活动困难图中低心情弹窗与推荐编队的处理流程。

## 主要改动

- 拆分情绪控制中的“账本计算”和“仅处理弹窗”两类场景，新增 `Emotion_PopupOnly` / `should_track` 判定，避免活动困难图等 popup-only 场景误触发心情等待或扣减。
- 低心情弹窗出现时，在 calculate 模式下改为取消出击、按舰队重置情绪账本、计算恢复时间，并延后当前任务。
- 战斗入口相关模块同步传递 `fleet_index`，使 `combat`、`raid`、`event_hospital`、`gems_farming`、`auto_search_combat`、`map` 的低心情处理能定位到对应舰队。
- 为活动困难图和特殊关卡增加 popup-only 适配，处理 `event_*` 下 `ht/c/d` 前缀关卡，并在推荐编队流程中处理确认弹窗，避免卡在推荐/确认界面。
- 增加进图前情绪校准：从船坞扫描指定常规舰队的最低心情，并同步回当前任务的情绪记录，减少脚本账本与游戏实际心情不一致导致的误判。
- 修正白色取消弹窗处理逻辑，避免 `POPUP_CANCEL_WHITE` 被误点为 `POPUP_CONFIRM_WHITE`。
- 补齐部分活动/作战档案关卡名转换列表，保持新活动与归档关卡的命名兼容。