### PR TITLE
Fix legacy template matching calls that still pass similarity values through threshold

### DIFF
--- a/module/map/map_operation.py
+++ b/module/map/map_operation.py
@@ -312,7 +312,7 @@ class MapOperation(MysteryHandler, FleetPreparation, Retirement, FastForwardHand
             MAP_MODE_SWITCH_HARD5,
             MAP_MODE_SWITCH_HARD6,
         ]:
-            if self.appear(button, offset=(20, 20), threshold=0.7):
+            if self.appear(button, offset=(20, 20), similarity=0.7):
                 if active:
                     return self._is_mod_switch_hard_active(button)
                 else:

--- a/module/os/globe_operation.py
+++ b/module/os/globe_operation.py
@@ -140,7 +140,7 @@ class GlobeOperation(ActionPointHandler):
         # Lower threshold to 0.75
         # Don't know why buy but fonts are different sometimes
         return [select for select in ZONE_SELECT if
-                self.appear(select, offset=self._zone_select_offset, threshold=self._zone_select_similarity)]
+                self.appear(select, offset=self._zone_select_offset, similarity=self._zone_select_similarity)]
 
     def is_in_zone_select(self):
         """
@@ -190,7 +190,7 @@ class GlobeOperation(ActionPointHandler):
             if self.is_zone_pinned():
                 break
             if self.appear_then_click(
-                    button, offset=self._zone_select_offset, threshold=self._zone_select_similarity, interval=5):
+                    button, offset=self._zone_select_offset, similarity=self._zone_select_similarity, interval=5):
                 continue
 
     def zone_type_select(self, types=('SAFE', 'DANGEROUS')):


### PR DESCRIPTION
After `ModuleBase.appear()` renamed template matching `threshold` to `similarity`( https://github.com/LmeSzinc/AzurLaneAutoScript/commit/164db6f4d ), these calls with `offset` were falling back to the default similarity instead of using the intended relaxed values.