### PR TITLE
fix(coalition): reverse mode switch state mapping for Frostfall rerun on TW server

### DIFF
--- a/module/coalition/ui.py
+++ b/module/coalition/ui.py
@@ -39,8 +39,8 @@ class CoalitionUI(Combat):
         if event == 'coalition_20230323':
             mode_switch = Switch('CoalitionMode', offset=(20, 20))
             # Note that switch button are reversed
-            mode_switch.add_state('story', FROSTFALL_MODE_STORY)
-            mode_switch.add_state('battle', FROSTFALL_MODE_BATTLE)
+            mode_switch.add_state('story', FROSTFALL_MODE_BATTLE)
+            mode_switch.add_state('battle', FROSTFALL_MODE_STORY)
         elif event == 'coalition_20240627':
             mode_switch = Switch('CoalitionMode', offset=(20, 20))
             mode_switch.add_state('story', ACADEMY_MODE_BATTLE)


### PR DESCRIPTION
目前**台服 (TW server)** 正在进行极地风暴复刻（`coalition_20230323`）活动。在此活动中，由于 `mode_switch` 的状态定义与实际界面按钮显示反向，导致程序在已经是战斗（Battle）模式时，误判为剧情（Story）模式，并进行了模式切换点击，将游戏切回了剧情模式，导致找不到战斗关卡（如 TC3）而卡死。
本 PR 交换了这两个状态的判定按钮，使其与代码中的注释 `# Note that switch button are reversed` 相吻合，可以让台服极地风暴活动正常工作。

### Verification / 验证

#### Before (修复前日志)
`in_coalition()` matched `page_coalition` successfully, but the script misidentified the mode as `story` and clicked `FROSTFALL_MODE_STORY`, switching the game from `battle` to `story` mode. As a result, it couldn't enter `TC3` and clicked empty spaces repeatedly:
```text
INFO     02:07:03.818 │ Page arrive: page_coalition
INFO     02:07:03.885 │ CoalitionMode set to battle                                
INFO     02:07:03.895 │ [CoalitionMode] story                                      
INFO     02:07:03.896 │ Click ( 116,  636) @ FROSTFALL_MODE_STORY                  
INFO     02:07:07.086 │ [CoalitionMode] unknown                                    
INFO     02:07:07.277 │ [CoalitionMode] battle   <-- 这里切换到了剧情模式
...
INFO     02:07:07.409 │ Click ( 824,  370) @ FROSTFALL_TC3
INFO     02:07:12.507 │ Click ( 823,  366) @ FROSTFALL_TC3
...
CRITICAL │ Failed to enter FROSTFALL_TC3, too many click on FROSTFALL_TC3

#### After(修复后日志)
INFO     02:45:48.473 │ COALITION_20230323_TC3                                     
INFO     02:45:48.474 │ Count: 0                                                   
INFO     02:45:48.475 │ UI get current page                                        
INFO     02:45:48.483 │ [UI] page_main                                             
INFO     02:45:48.484 │ <<< UI GOTO PAGE_CAMPAIGN_MENU >>>                         
INFO     02:45:48.489 │ Page switch: page_main_white -> page_campaign_menu         
INFO     02:45:48.491 │ Click (1173,  489) @ MAIN_GOTO_CAMPAIGN_WHITE              
INFO     02:45:53.505 │ Page switch: page_main_white -> page_campaign_menu         
INFO     02:45:53.506 │ Click (1147,  525) @ MAIN_GOTO_CAMPAIGN_WHITE              
INFO     02:45:53.903 │ Page arrive: page_campaign_menu                            
INFO     02:45:53.905 │ Event available                                            
INFO     02:45:53.906 │ <<< UI GOTO PAGE_COALITION >>>                             
INFO     02:45:53.909 │ Page switch: page_campaign_menu -> page_coalition          
INFO     02:45:53.910 │ Click ( 694,  197) @ CAMPAIGN_MENU_GOTO_EVENT              
INFO     02:45:54.104 │ Page arrive: page_coalition                                
INFO     02:45:54.111 │ Bind task ['General', 'Alas', 'TaskBalancer',              
         'EventGeneral', 'Coalition']                                              
INFO     02:45:54.113 │ CoalitionMode set to battle                                
INFO     02:45:54.133 │ [CoalitionMode] battle                                     
INFO     02:45:54.160 │ [FROSTFALL_OCR_PT 0.024s] 18955                            
INFO     02:45:54.162 │ [Event_PT_limit] 18955/140000                              
INFO     02:45:54.164 │ Expect emotion reduce: (6, 0)                              
INFO     02:45:54.170 │ Bind task ['General', 'Alas', 'TaskBalancer',              
         'EventGeneral', 'Coalition']                                              
INFO     02:45:54.171 │ Save config ./config\alas.json,                            
         Coalition.Emotion.Fleet1Value=109,                                        
         Coalition.Emotion.Fleet1Record=datetime.datetime(2026, 7, 5, 2, 45, 54),  
         Coalition.Emotion.Fleet2Value=119,                                        
         Coalition.Emotion.Fleet2Record=datetime.datetime(2026, 7, 5, 2, 45, 54)   
INFO     02:45:54.180 │ [Emotion fleet_1] 109                                      
INFO     02:45:54.182 │ [Emotion fleet_2] 119                                      
INFO     02:45:54.193 │ No oil icon                                                
INFO     02:45:54.307 │ No oil icon                                                
INFO     02:45:54.536 │ [OCR_OIL 0.026s] 7632                                      
INFO     02:45:54.548 │ Click ( 813,  366) @ FROSTFALL_TC3                         
INFO     02:45:54.936 │ Click (1058,  526) @ FROSTFALL_FLEET_PREPARATION  