### PR TITLE
Fix: support macOS arm64 packaged webapp startup

### DIFF
--- a/webapp/packages/main/src/config.ts
+++ b/webapp/packages/main/src/config.ts
@@ -3,14 +3,88 @@ const fs = require('fs');
 const path = require('path');
 
 // export const alasPath = 'D:/AzurLaneAutoScript';
-export const alasPath = process.cwd();
+function findAlasPath() {
+  const roots = [
+    process.cwd(),
+    __dirname,
+    process.execPath,
+  ];
+  const configFiles = ['./config/deploy.yaml'];
+
+  for (const root of roots) {
+    let current = fs.statSync(root).isDirectory() ? root : path.dirname(root);
+    let searching = true;
+    while (searching) {
+      for (const configFile of configFiles) {
+        if (fs.existsSync(path.join(current, configFile))) {
+          return current;
+        }
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) {
+        searching = false;
+      } else {
+        current = parent;
+      }
+    }
+  }
+
+  return process.cwd();
+}
+
+export const alasPath = findAlasPath();
 
 const file = fs.readFileSync(path.join(alasPath, './config/deploy.yaml'), 'utf8');
 const config = yaml.parse(file);
 const PythonExecutable = config.Deploy.Python.PythonExecutable;
 const WebuiPort = config.Deploy.Webui.WebuiPort.toString();
 
-export const pythonPath = (path.isAbsolute(PythonExecutable) ? PythonExecutable : path.join(alasPath, PythonExecutable));
+function resolvePath(filePath: string) {
+  return path.isAbsolute(filePath) ? filePath : path.join(alasPath, filePath);
+}
+
+function findMacArmCondaPython() {
+  if (process.platform !== 'darwin' || process.arch !== 'arm64') {
+    return null;
+  }
+
+  const home = process.env.HOME;
+  const envPaths = [
+    path.join(alasPath, 'alas'),
+    path.join(alasPath, 'envs', 'alas'),
+    path.join(alasPath, '.conda', 'envs', 'alas'),
+    home ? path.join(home, '.conda', 'envs', 'alas') : null,
+    home ? path.join(home, 'miniconda3', 'envs', 'alas') : null,
+    home ? path.join(home, 'miniforge3', 'envs', 'alas') : null,
+    home ? path.join(home, 'anaconda3', 'envs', 'alas') : null,
+    '/opt/homebrew/Caskroom/miniconda/base/envs/alas',
+    '/opt/homebrew/Caskroom/miniforge/base/envs/alas',
+  ];
+
+  for (const envPath of envPaths) {
+    if (!envPath) {
+      continue;
+    }
+    const python = path.join(envPath, 'bin', 'python');
+    if (fs.existsSync(python)) {
+      return python;
+    }
+  }
+
+  return null;
+}
+
+function resolvePythonPath() {
+  const configuredPython = resolvePath(PythonExecutable);
+  if (fs.existsSync(configuredPython)) {
+    return configuredPython;
+  }
+
+  return findMacArmCondaPython() || configuredPython;
+}
+
+export const pythonPath = resolvePythonPath();
 export const webuiUrl = `http://127.0.0.1:${WebuiPort}`;
 export const webuiPath = 'gui.py';
 export const webuiArgs = ['--port', WebuiPort, '--electron'];


### PR DESCRIPTION
## Summary
- locate the ALAS root for packaged Electron launches instead of relying on `process.cwd()`
- keep the configured `Deploy.Python.PythonExecutable` when it exists
- add a macOS arm64 fallback that looks for a local `alas` conda environment when the default Windows `./toolkit/python.exe` path is missing

## Problem
Fixes #5105.

On macOS arm64, the packaged Electron app can start from Finder or another non-repo working directory. In that case the main process should not assume `process.cwd()` is the project root. The default Python path in `config/deploy.yaml` also points to `./toolkit/python.exe`, which does not exist on Apple Silicon setups and causes `spawn .../toolkit/python.exe ENOENT`.

Issue #1873 already shows that Apple Silicon users need to provide their own Python environment. This change keeps the current config-first behavior, but lets the packaged app recover by using a local `alas` conda environment when the configured Windows path is unavailable.

## Verification
- `cd webapp && PATH=/Users/acfufu/.nvm/versions/node/v16.20.2/bin:$PATH npm run typecheck`
- `cd webapp && PATH=/Users/acfufu/.nvm/versions/node/v16.20.2/bin:$PATH npm run build`
- `cd webapp && PATH=/Users/acfufu/.nvm/versions/node/v16.20.2/bin:$PATH npm run compile`
- launched `webapp/dist/mac-arm64/alas.app/Contents/MacOS/alas` from `/tmp`
- confirmed the packaged app responded on `http://127.0.0.1:22267/` without `toolkit/python.exe` spawn errors

## Notes
- the repository pre-push hook currently runs `npm run typecheck` from the repo root, but the only `package.json` is under `webapp/`, so that hook fails before checking the actual webapp workspace
- `npm test` still times out in the existing Electron smoke test while waiting for the first window, even though the packaged app and WebUI start successfully