### PR TITLE
Improve OCR import diagnostics

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -5,6 +5,9 @@ FROM python:3.7-slim-bullseye
 
 WORKDIR /app/AzurLaneAutoScript
 
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONFAULTHANDLER=1
+
 COPY requirements.txt /tmp/requirements.txt
 
 # Initial download of UiAutomator2 is slow outside of China using appetizer mirror, switch to GitHub

--- a/deploy/docker/Dockerfile.cn
+++ b/deploy/docker/Dockerfile.cn
@@ -5,6 +5,9 @@ FROM python:3.7-slim-bullseye
 
 WORKDIR /app/AzurLaneAutoScript
 
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONFAULTHANDLER=1
+
 COPY requirements.txt /tmp/requirements.txt
 
 # python:3.7-slim is based on debian:11, apt source from https://developer.aliyun.com/mirror/debian

--- a/module/base/base.py
+++ b/module/base/base.py
@@ -80,17 +80,20 @@ class ModuleBase:
             return
 
         def do_ocr_import():
-            # Wait first image
-            import time
-            while 1:
-                if self.device.has_cached_image:
-                    break
-                time.sleep(0.01)
+            try:
+                # Wait first image
+                import time
+                while 1:
+                    if self.device.has_cached_image:
+                        break
+                    time.sleep(0.01)
 
-            logger.info('early_ocr_import start')
-            from module.ocr.al_ocr import AlOcr
-            _ = AlOcr
-            logger.info('early_ocr_import finish')
+                logger.info('early_ocr_import start')
+                from module.ocr.al_ocr import AlOcr
+                _ = AlOcr
+                logger.info('early_ocr_import finish')
+            except Exception:
+                logger.exception('early_ocr_import failed')
 
         logger.info('early_ocr_import call')
         import threading


### PR DESCRIPTION
﻿## Summary
- Log exceptions raised by the background `early_ocr_import` thread instead of only letting the thread die silently.
- Enable unbuffered Python output and `faulthandler` in Docker images, so fatal OCR dependency crashes such as SIGILL/SIGSEGV can leave useful diagnostics in container logs.

## Why
This makes OCR startup failures easier to diagnose in Docker/headless deployments. It is especially helpful for cases where execution stops around `Loading OCR dependencies` with no Python traceback.

Refs #5772

## Test
- `python -m py_compile module/base/base.py`
