### PR TITLE
Fix Windows deploy repository redirects

### DIFF
--- a/deploy/Windows/config.py
+++ b/deploy/Windows/config.py
@@ -119,7 +119,7 @@ class DeployConfig(ConfigModel):
         # Don't write these into deploy.yaml
         super().__setattr__('GitOverCdn', self.Repository in ['cn'])
         if self.Repository in ['global', 'cn']:
-            super().__setattr__('Repository', 'https://github.com/LmeSzinc/StarRailCopilot')
+            super().__setattr__('Repository', 'https://github.com/LmeSzinc/AzurLaneAutoScript')
 
     def filepath(self, path):
         """

--- a/deploy/Windows/git.py
+++ b/deploy/Windows/git.py
@@ -116,8 +116,11 @@ class GitManager(DeployConfig):
 
     @property
     def goc_client(self):
-        client = GitOverCdnClient(
-            url='https://vip.123pan.cn/1815343254/pack/LmeSzinc_StarRailCopilot_master',
+        client = GitOverCdnClientWindows(
+            url=[
+                'https://1818706573.cdn.123clouddisk.com/1818706573/pack/LmeSzinc_AzurLaneAutoScript_master',
+                'https://vip.123pan.cn/1818706573/pack/LmeSzinc_AzurLaneAutoScript_master',
+            ],
             folder=self.root_filepath,
             source='origin',
             branch='master',

--- a/deploy/Windows/template.yaml
+++ b/deploy/Windows/template.yaml
@@ -2,7 +2,7 @@ Deploy:
   Git:
     # URL of AzurLaneAutoScript repository
     # [CN user] Use 'cn' to get update from git-over-cdn service
-    # [Other] Use 'global' to get update from https://github.com/LmeSzinc/StarRailCopilot
+    # [Other] Use 'global' to get update from https://github.com/LmeSzinc/AzurLaneAutoScript
     Repository: 'global'
     # Branch of Alas
     # [Developer] Use 'dev', 'app', etc, to try new features


### PR DESCRIPTION
﻿## Summary
- Fix `deploy/Windows` repository redirection so `global` / `cn` resolve to `LmeSzinc/AzurLaneAutoScript` instead of `LmeSzinc/StarRailCopilot`.
- Point the Windows Git-over-CDN updater at the AzurLaneAutoScript CDN packs.
- Use `GitOverCdnClientWindows` so the Windows progress callbacks defined in this file are actually used.
- Update the Windows deploy template comment to mention the correct repository.

## Why
The Windows deployment helper lives in the AzurLaneAutoScript repo, but part of its redirect/CDN config still referenced StarRailCopilot. If this path is used, it can fetch or display the wrong repository target.

## Test
- `python -m py_compile deploy/Windows/config.py deploy/Windows/git.py`
- Local smoke test for:
  - `Repository: global` redirects to `https://github.com/LmeSzinc/AzurLaneAutoScript`
  - `Repository: cn` enables Git-over-CDN and still uses the AzurLaneAutoScript fallback repo
  - Windows GOC client is `GitOverCdnClientWindows` and points to AzurLaneAutoScript CDN URLs
