### PR TITLE
Fix daily inactive card detection

### DIFF
--- a/module/daily/daily.py
+++ b/module/daily/daily.py
@@ -25,6 +25,13 @@ class Daily(Combat, DailyEquipment):
     emergency_module_development = False
 
     def is_active(self):
+        # Inactive daily entries can still have bright/red text around
+        # DAILY_ACTIVE. Detect the lock overlay first to avoid clicking an
+        # unavailable card repeatedly.
+        if self.appear(DAILY_LOCKED, threshold=30):
+            logger.attr(f'Daily_{self.daily_current}', 'inactive')
+            return False
+
         color = get_color(image=self.device.image, area=DAILY_ACTIVE.area)
         color = np.array(color).astype(float)
         color = (np.max(color) + np.min(color)) / 2


### PR DESCRIPTION
﻿## Summary
- Treat a visible lock overlay on the current daily card as inactive before using the older `DAILY_ACTIVE` brightness check.
- This prevents Alas from repeatedly clicking `DAILY_ENTER` on unavailable daily cards that can still be misclassified as active.

## Why
In #5692, Alas sometimes recognized an unavailable daily card as active and then kept clicking the daily entrance until `GameTooManyClickError`.

## Test
- `python -m py_compile module/daily/daily.py`
- Local smoke check that `DAILY_LOCKED` detects the unavailable cards in the screenshots from #5692.

Fixes #5692
