### PR TITLE
Fix medal shop missing scroll detection

### DIFF
--- a/module/shop/shop_medal.py
+++ b/module/shop/shop_medal.py
@@ -274,6 +274,13 @@ class MedalShop2_250814(ShopClerk, ShopStatus):
 
             self.shop_buy()
 
+            # Some emulator renderers can draw the medal-shop scrollbar as a
+            # solid/undetectable bar. In that case cal_position() stays at the
+            # default top position and next_page() would keep swiping forever.
+            if not MEDAL_SHOP_SCROLL_250814.appear(main=self):
+                logger.warning('Medal shop scroll not detected, stop')
+                break
+
             if MEDAL_SHOP_SCROLL_250814.at_bottom(main=self):
                 logger.info('Medal shop reach bottom, stop')
                 break


### PR DESCRIPTION
﻿## Summary
- Stop Medal Shop pagination when the adaptive scrollbar is not detected
- Prevent repeated swipes on renderers that draw the Medal Shop scrollbar as a solid/undetectable bar

## Why
Issue #5652 shows `MEDAL_SHOP_SCROLL_250814` logging `nan` for the detected thumb position, then repeatedly swiping until `GameTooManyClickError` restarts the game. If the scrollbar cannot be detected, continuing to paginate is unsafe, so this stops the Medal Shop loop instead of getting stuck.

Fixes #5652

## Test
- `python -m py_compile module\shop\shop_medal.py module\ui\scroll.py`
