### PR TITLE
Fix MuMu 15 keep-alive config lookup

### DIFF
--- a/module/device/method/nemu_ipc.py
+++ b/module/device/method/nemu_ipc.py
@@ -572,10 +572,17 @@ class NemuIpc(Platform):
         if self.config.EmulatorInfo_path:
             index = NemuIpcImpl.serial_to_id(self.serial)
             if index is not None:
-                file = os.path.abspath(os.path.join(
-                    self.config.EmulatorInfo_path, f'../../vms/MuMuPlayer-12.0-{index}/configs/customer_config.json'))
-                if self.check_mumu_app_keep_alive_400(file):
-                    return True
+                vms = os.path.abspath(os.path.join(self.config.EmulatorInfo_path, '../../vms'))
+                for name in [
+                    f'MuMuPlayer-15.0-{index}',
+                    f'MuMuPlayerGlobal-15.0-{index}',
+                    f'MuMuPlayer-12.0-{index}',
+                    f'MuMuPlayerGlobal-12.0-{index}',
+                    f'YXArkNights-12.0-{index}',
+                ]:
+                    file = os.path.join(vms, name, 'configs/customer_config.json')
+                    if os.path.exists(file) and self.check_mumu_app_keep_alive_400(file):
+                        return True
 
         # Search emulator instance
         if self.emulator_instance is None:


### PR DESCRIPTION
﻿## Summary
- Look up MuMu 15.0 instance config paths when checking `customer.app_keptlive`
- Avoid probing only `MuMuPlayer-12.0-{index}` for MuMu 6 / Android 15 instances
- Keep the existing MuMu 12.0 and Global/YXArkNights fallbacks

## Why
The log in #5778 shows a detected instance named `MuMuPlayer-15.0-2`, but the keep-alive preflight first checks `vms/MuMuPlayer-12.0-2/configs/customer_config.json`, producing a misleading missing-file warning for Android 15 instances. Checking the 15.0 config path first makes the preflight match the detected MuMu instance layout.

Refs #5778

## Test
- `python -m py_compile module\device\method\nemu_ipc.py`
