### PR TITLE
Fix gems emotion handling without auto search

### DIFF
--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -352,7 +352,7 @@ class GemsFarming(CampaignRun, FleetEquipment, Dock):
             logger.hr('TRIGGERED LV32 LIMIT')
             return True
 
-        if self.campaign.map_is_auto_search and self.campaign.config.GEMS_EMOTION_TRIGGERED:
+        if self.campaign.config.GEMS_EMOTION_TRIGGERED:
             self._trigger_emotion = True
             logger.hr('TRIGGERED EMOTION LIMIT')
             return True


### PR DESCRIPTION
﻿## Summary
- Let GemsFarming handle `GEMS_EMOTION_TRIGGERED` even when auto search is disabled
- Prevent non-auto-search low-emotion withdraws from immediately starting the same stage again without changing ships

## Why
Issue #5464 reports that with non-auto search and low-emotion ship replacement enabled, Alas withdraws from the current battle but then starts the stage again instead of entering fleet setup to replace the vanguard. `GEMS_EMOTION_TRIGGERED` is already set by the low-emotion handler, but `triggered_stop_condition()` only honored it while `map_is_auto_search` was true.

Fixes #5464

## Test
- `python -m py_compile module\campaign\gems_farming.py`
