### PR TITLE
Fix: [CN] core monthly shop never scrolls, items on later pages can never be bought

### DIFF
--- a/module/shop/shop_core.py
+++ b/module/shop/shop_core.py
@@ -1,6 +1,3 @@
-import cv2
-import numpy as np
-
 from module.base.button import ButtonGrid
 from module.base.decorator import cached_property, del_cached_property
 from module.base.template import Template
@@ -9,14 +6,26 @@ from module.map_detection.utils import Points
 from module.shop.assets import *
 from module.shop.base import ShopItemGrid, ShopItemGrid_250814
 from module.shop.clerk import ShopClerk
+from module.shop.shop_medal import ShopScroll
 from module.shop.shop_status import ShopStatus
 
 TEMPLATE_CORE_ICON = Template('./assets/shop/cost/Core_4.png')
-# Item list, used to swipe and to tell whether list has moved
-CORE_SHOP_ITEM_AREA = (220, 195, 1050, 640)
-# About 1.7 rows, small enough not to skip a row, large enough to make progress
-CORE_SHOP_SWIPE_DISTANCE = 380
-CORE_SHOP_SWIPE_LIMIT = 20
+
+
+class CoreShopScroll(ShopScroll):
+    def position_to_screen(self, position, random_range=(-0.01, 0.01)):
+        return super().position_to_screen(position, random_range=random_range)
+
+
+CORE_SHOP_SCROLL_250814 = CoreShopScroll(
+    MEDAL_SHOP_SCROLL_AREA_250814.button,
+    color=(44, 48, 56),
+    name='CORE_SHOP_SCROLL_250814'
+)
+# Core shop has a much shorter slider than medal shop, keep the drag accurate
+# enough to leave overlap between pages
+CORE_SHOP_SCROLL_250814.drag_threshold = 0.03
+CORE_SHOP_SCROLL_LIMIT = 20
 
 
 class CoreShop_250814(ShopClerk, ShopStatus):
@@ -153,58 +162,6 @@ class CoreShop_250814(ShopClerk, ShopStatus):
 
         return False
 
-    def shop_swipe(self, distance, name='CORE_SHOP_SWIPE'):
-        """
-        Swipe item list and tell whether it actually moved.
-
-        Swiping the list instead of dragging the scrollbar, because the lower half
-        of the scrollbar overlaps a dark character illustration and loses contrast
-        there, making scroll position unreadable near the bottom.
-
-        Args:
-            distance (int): Pixels to swipe, negative to show following items.
-            name (str):
-
-        Returns:
-            bool: True if item list moved, False if it already reached the end.
-        """
-        before = self.image_crop(CORE_SHOP_ITEM_AREA, copy=True)
-        x = (CORE_SHOP_ITEM_AREA[0] + CORE_SHOP_ITEM_AREA[2]) // 2
-        y = (CORE_SHOP_ITEM_AREA[1] + CORE_SHOP_ITEM_AREA[3]) // 2
-        # drag instead of swipe, so the shake at the end cancels inertia,
-        # otherwise list keeps sliding and skips rows that were never detected
-        self.device.drag((x, y - distance // 2), (x, y + distance // 2), segments=2, shake=(0, 25),
-                         point_random=(0, 0, 0, 0), shake_random=(0, -5, 0, 5), name=name)
-        # Going through the whole list takes more swipes than the too-many-click
-        # guard allows, drop them as they are expected repetitions
-        self.device.click_record_remove(name)
-        self.device.sleep(0.5)
-        self.device.screenshot()
-        after = self.image_crop(CORE_SHOP_ITEM_AREA, copy=True)
-
-        # Item cards are static, moving the list gives a difference of tens
-        difference = float(np.mean(cv2.absdiff(before, after)))
-        moved = difference > 5
-        logger.attr(name, f'{"moved" if moved else "stuck"}, difference={difference:.1f}')
-        if moved:
-            del_cached_property(self, 'shop_grid')
-            del_cached_property(self, 'shop_core_items')
-        return moved
-
-    def shop_swipe_top(self):
-        """
-        Swipe item list back to top, so no item is missed no matter where the
-        list was left at.
-
-        Returns:
-            bool: True if item list reached top, False if swipe limit was reached.
-        """
-        for _ in range(CORE_SHOP_SWIPE_LIMIT):
-            if not self.shop_swipe(CORE_SHOP_SWIPE_DISTANCE, name='CORE_SHOP_SWIPE_TOP'):
-                return True
-        logger.warning('Failed to swipe core shop to top')
-        return False
-
     def run(self):
         """
         Run Core Shop
@@ -219,15 +176,18 @@ class CoreShop_250814(ShopClerk, ShopStatus):
 
         # Core monthly shop holds about 20 rows of items while only 2 rows are
         # visible, items must be scrolled through page by page
-        if not self.shop_swipe_top():
-            return
-        for _ in range(CORE_SHOP_SWIPE_LIMIT):
+        for _ in range(CORE_SHOP_SCROLL_LIMIT):
             # Execute buy operations
             if not self.shop_buy():
                 break
 
-            if not self.shop_swipe(-CORE_SHOP_SWIPE_DISTANCE, name='CORE_SHOP_SWIPE_NEXT'):
+            if CORE_SHOP_SCROLL_250814.at_bottom(main=self):
                 logger.info('Core shop reach bottom, stop')
                 break
+
+            CORE_SHOP_SCROLL_250814.next_page(main=self, page=0.66)
+            self.device.click_record_remove(CORE_SHOP_SCROLL_250814.name)
+            del_cached_property(self, 'shop_grid')
+            del_cached_property(self, 'shop_core_items')
         else:
             logger.warning('Too many pages in core shop, stopped')

--- a/module/shop/shop_core.py
+++ b/module/shop/shop_core.py
@@ -16,6 +16,7 @@ TEMPLATE_CORE_ICON = Template('./assets/shop/cost/Core_4.png')
 CORE_SHOP_ITEM_AREA = (220, 195, 1050, 640)
 # About 1.7 rows, small enough not to skip a row, large enough to make progress
 CORE_SHOP_SWIPE_DISTANCE = 380
+CORE_SHOP_SWIPE_LIMIT = 20
 
 
 class CoreShop_250814(ShopClerk, ShopStatus):
@@ -194,11 +195,15 @@ class CoreShop_250814(ShopClerk, ShopStatus):
         """
         Swipe item list back to top, so no item is missed no matter where the
         list was left at.
+
+        Returns:
+            bool: True if item list reached top, False if swipe limit was reached.
         """
-        for _ in range(10):
+        for _ in range(CORE_SHOP_SWIPE_LIMIT):
             if not self.shop_swipe(CORE_SHOP_SWIPE_DISTANCE, name='CORE_SHOP_SWIPE_TOP'):
-                return
+                return True
         logger.warning('Failed to swipe core shop to top')
+        return False
 
     def run(self):
         """
@@ -214,8 +219,9 @@ class CoreShop_250814(ShopClerk, ShopStatus):
 
         # Core monthly shop holds about 20 rows of items while only 2 rows are
         # visible, items must be scrolled through page by page
-        self.shop_swipe_top()
-        for _ in range(20):
+        if not self.shop_swipe_top():
+            return
+        for _ in range(CORE_SHOP_SWIPE_LIMIT):
             # Execute buy operations
             if not self.shop_buy():
                 break

--- a/module/shop/shop_core.py
+++ b/module/shop/shop_core.py
@@ -1,9 +1,21 @@
-from module.base.decorator import cached_property
+import cv2
+import numpy as np
+
+from module.base.button import ButtonGrid
+from module.base.decorator import cached_property, del_cached_property
+from module.base.template import Template
 from module.logger import logger
+from module.map_detection.utils import Points
 from module.shop.assets import *
 from module.shop.base import ShopItemGrid, ShopItemGrid_250814
 from module.shop.clerk import ShopClerk
 from module.shop.shop_status import ShopStatus
+
+TEMPLATE_CORE_ICON = Template('./assets/shop/cost/Core_4.png')
+# Item list, used to swipe and to tell whether list has moved
+CORE_SHOP_ITEM_AREA = (220, 195, 1050, 640)
+# About 1.7 rows, small enough not to skip a row, large enough to make progress
+CORE_SHOP_SWIPE_DISTANCE = 380
 
 
 class CoreShop_250814(ShopClerk, ShopStatus):
@@ -18,6 +30,59 @@ class CoreShop_250814(ShopClerk, ShopStatus):
         return self.config.CoreShop_Filter.strip()
 
     # New UI in 2025-08-14
+    def _get_cores(self):
+        """
+        Returns:
+            np.array: [[x1, y1], [x2, y2]], location of the core icon upper-left corner.
+        """
+        area = (250, 190, 1000, 645)
+        # copy image because matchTemplate needs a continuous array
+        image = self.image_crop(area, copy=True)
+        cores = TEMPLATE_CORE_ICON.match_multi(image, similarity=0.8, threshold=5)
+        cores = Points([(0., c.area[1]) for c in cores]).group(threshold=5)
+        logger.attr('Core_icon', len(cores))
+        return cores
+
+    @cached_property
+    def shop_grid(self):
+        """
+        Item rows are only aligned with the static grid when list is at top,
+        so locate them by the core icon in price bar, like medal shop does.
+
+        Returns:
+            ButtonGrid:
+        """
+        cores = self._get_cores()
+        count = len(cores)
+        if count == 0:
+            logger.warning('Unable to find core icon, assume item list is at top')
+            origin_y = 238
+            delta_y = 223
+            row = 2
+        elif count == 1:
+            y_list = cores[:, 1]
+            # +190, top of the crop area in _get_cores()
+            # -129, from the top of core icon to the top of shop item
+            origin_y = y_list[0] + 190 - 129
+            delta_y = 223
+            row = 1
+        elif count == 2:
+            y_list = cores[:, 1]
+            y1, y2 = y_list[0], y_list[1]
+            origin_y = min(y1, y2) + 190 - 129
+            delta_y = abs(y1 - y2)
+            row = 2
+        else:
+            logger.warning(f'Unexpected core icon match result: {[c for c in cores]}')
+            origin_y = 238
+            delta_y = 223
+            row = 2
+
+        shop_grid = ButtonGrid(
+            origin=(265, origin_y), delta=(169, delta_y), button_shape=(64, 64), grid_shape=(5, row),
+            name='SHOP_GRID')
+        return shop_grid
+
     @cached_property
     def shop_core_items(self):
         """
@@ -87,6 +152,54 @@ class CoreShop_250814(ShopClerk, ShopStatus):
 
         return False
 
+    def shop_swipe(self, distance, name='CORE_SHOP_SWIPE'):
+        """
+        Swipe item list and tell whether it actually moved.
+
+        Swiping the list instead of dragging the scrollbar, because the lower half
+        of the scrollbar overlaps a dark character illustration and loses contrast
+        there, making scroll position unreadable near the bottom.
+
+        Args:
+            distance (int): Pixels to swipe, negative to show following items.
+            name (str):
+
+        Returns:
+            bool: True if item list moved, False if it already reached the end.
+        """
+        before = self.image_crop(CORE_SHOP_ITEM_AREA, copy=True)
+        x = (CORE_SHOP_ITEM_AREA[0] + CORE_SHOP_ITEM_AREA[2]) // 2
+        y = (CORE_SHOP_ITEM_AREA[1] + CORE_SHOP_ITEM_AREA[3]) // 2
+        # drag instead of swipe, so the shake at the end cancels inertia,
+        # otherwise list keeps sliding and skips rows that were never detected
+        self.device.drag((x, y - distance // 2), (x, y + distance // 2), segments=2, shake=(0, 25),
+                         point_random=(0, 0, 0, 0), shake_random=(0, -5, 0, 5), name=name)
+        # Going through the whole list takes more swipes than the too-many-click
+        # guard allows, drop them as they are expected repetitions
+        self.device.click_record_remove(name)
+        self.device.sleep(0.5)
+        self.device.screenshot()
+        after = self.image_crop(CORE_SHOP_ITEM_AREA, copy=True)
+
+        # Item cards are static, moving the list gives a difference of tens
+        difference = float(np.mean(cv2.absdiff(before, after)))
+        moved = difference > 5
+        logger.attr(name, f'{"moved" if moved else "stuck"}, difference={difference:.1f}')
+        if moved:
+            del_cached_property(self, 'shop_grid')
+            del_cached_property(self, 'shop_core_items')
+        return moved
+
+    def shop_swipe_top(self):
+        """
+        Swipe item list back to top, so no item is missed no matter where the
+        list was left at.
+        """
+        for _ in range(10):
+            if not self.shop_swipe(CORE_SHOP_SWIPE_DISTANCE, name='CORE_SHOP_SWIPE_TOP'):
+                return
+        logger.warning('Failed to swipe core shop to top')
+
     def run(self):
         """
         Run Core Shop
@@ -99,5 +212,16 @@ class CoreShop_250814(ShopClerk, ShopStatus):
         # correct Core Shop interface
         logger.hr('Core Shop', level=1)
 
-        # Execute buy operations
-        self.shop_buy()
+        # Core monthly shop holds about 20 rows of items while only 2 rows are
+        # visible, items must be scrolled through page by page
+        self.shop_swipe_top()
+        for _ in range(20):
+            # Execute buy operations
+            if not self.shop_buy():
+                break
+
+            if not self.shop_swipe(-CORE_SHOP_SWIPE_DISTANCE, name='CORE_SHOP_SWIPE_NEXT'):
+                logger.info('Core shop reach bottom, stop')
+                break
+        else:
+            logger.warning('Too many pages in core shop, stopped')


### PR DESCRIPTION
## Summary

Fixes #5853 — the core monthly shop only processed the two visible rows, so items on later pages could never be found or bought, including the torpedo / AP shell / heavy shell templates added in #5837.

`CoreShop_250814.run()` called `shop_buy()` once and returned. In addition, the static item grid only matched the list while it was at the top; after scrolling, every item could fail `predict_valid` and the log would only report `No shop items found`.

## Changes

- Locate item rows by the core icon in the price bar (`assets/shop/cost/Core_4.png`, `origin_y = icon_y - 129`), following the same approach as the medal shop.
- Reuse the medal shop's background-compensated `ShopScroll` detection with color `(44, 48, 56)`.
- Keep a core-shop-specific scroll instance because its slider is shorter: use a narrower drag range and `drag_threshold = 0.03` so page movement is not discarded while pages still overlap.
- Scan page by page until the scrollbar reaches the bottom, invalidate the cached item grid after each page, and clear expected repeated scrollbar clicks from the click guard.
- Do not explicitly reset the list to the top: switching `NAV_GENERAL → NAV_MONTHLY → TAB_CORE_MONTHLY` resets the core monthly shop to the top.

## Testing

Tested on a live CN client in MuMu at 1280×720 with `nemu_ipc` screenshots and `minitouch` control.

- The final `ShopScroll` implementation completed 8 consecutive full-list scans during review testing without missing the physical bottom.
- After rebasing onto the latest `dev`, two additional no-purchase regression runs completed successfully.
- The latest run started at scrollbar position `0.00`, performed 14 page recognition passes, reached the bottom at `0.98`, and returned to the main page.
- Core balance remained `14946` on every page; an intentionally invalid in-memory filter ensured that no item could be selected or purchased.
- `Type93PureOxygenTorpedo`, `Type1ArmorPiercingShell`, and `SuperHeavyShell` were previously recognized with the correct names/groups, and their normal purchase flow was verified without buying any unrelated item.
- Runtime import and Python compilation checks pass.

Only CN has been tested. Row detection uses a text-free core icon and the scroll logic uses fixed geometry, so other servers are expected to behave the same, but remain unverified.