### PR TITLE
处理侵蚀一漏检特殊位置的明石

### DIFF
--- a/module/os/tasks/hazard_leveling.py
+++ b/module/os/tasks/hazard_leveling.py
@@ -3,6 +3,41 @@ from module.os.map import OSMap
 
 
 class OpsiHazard1Leveling(OSMap):
+
+    def clear_question(self, drop=None):
+        """
+        Clear a nearby question mark using any available fleet.
+
+        In rare cases, strategic search may leave the configured CL1 fleet too
+        far from Akashi (Issue #5656). The cause is unclear, but another fleet
+        may be closer to Akashi. Switch through the other fleets until one can
+        detect the question mark. For instance:
+        """
+        
+        primary = self.config.OpsiFleet_Fleet
+        fleets = [primary] + [
+            fleet for fleet in [1, 2, 3, 4]
+            if fleet != primary
+        ]
+
+        for fleet in fleets:
+            self.fleet_set(fleet)
+            self.device.screenshot()
+
+            grid = self.radar.predict_question(
+                self.device.image,
+                in_port=self.zone.is_port,
+            )
+
+            if grid is None:
+                logger.info(f'No nearby question mark for fleet {fleet}')
+                continue
+
+            logger.info(f'Found nearby question mark using fleet {fleet}')
+            return super().clear_question(drop=drop)
+
+        return False
+
     def os_hazard1_leveling(self):
         logger.hr('OS hazard 1 leveling', level=1)
         # Without these enabled, CL1 gains 0 profits


### PR DESCRIPTION
## 问题描述

侵蚀一的“计划作战”结算后，ALAS 会先检查出击舰队附近是否存在明石。若明石位于预设的相对位置内，脚本会直接前往处理；若附近没有发现明石，则会扫描地图上的特殊事件，例如明石、吊机和信息塔。

通常情况下，“计划作战”结算前，出击舰队会自动移动到明石附近。即使没有移动，后续的地图扫描一般也能发现明石。

但明石有概率刷新在 [#5656](https://github.com/LmeSzinc/AzurLaneAutoScript/issues/5656#issuecomment-5086847023) 所示的位置。此时，出击舰队不会自动移动到明石附近；同时，明石图标会被其下方的舰队图标遮挡，导致地图扫描也无法识别明石。

原有的 `clear_question()` 只会检查出击舰队附近几个固定的雷达相对位置：

```python
[(0, 1), (-1, 0), (1, 0), (0, -1), (0, -2), (0, -3)]
```

因此，在上述特殊情况下，虽然雷达已经识别到问号，但由于问号不在 `clear_question()` 的检查范围内，脚本仍会输出：

```text
No question mark above current fleet on this radar
```

最终，附近检查和地图扫描都会遗漏该明石，脚本随后跳过明石商店并开始下一轮战略搜索。因为明石是侵蚀一的核心事件，所以我们希望尽量避免任何“漏猫”的可能。

## 实际日志表现

在复现日志中，雷达能够识别到 `QU`，但问号位于原有检查范围之外：

```text
-- -- QU -- -- -- --
...
-- -- -- -- -- FL -- -- -- -- --
```

与此同时，明石又被舰队遮挡，因此地图扫描也无法发现她。

## 修改内容

本 PR 仅修改侵蚀一相关文件：

```text
module/os/tasks/hazard_leveling.py
```

主要修改如下：

1. 侵蚀一的“计划作战”结算意味着地图上存在需要处理的问号事件。
2. 如果出击舰队附近没有找到问号，则依次切换至其他舰队并重新扫描，以排查被舰队遮挡、刷新在该特殊位置的明石。

## 测试和问题

1. 问题已解决，但在短猫中似乎也会触发一次额外检索。由于这种情况非常少见，测试近两周仅出现三次，因此暂时无法确定该改动在实际使用中是否有明显价值。考虑到这本身也是一个小众需求，建议酌情合并。