### PR TITLE
Add: 军需商店未拥有舰船购买 |merit shop unget ribbon detection & Unget filter category

### DIFF
--- a/module/shop/base.py
+++ b/module/shop/base.py
@@ -17,7 +17,7 @@ from module.ui.ui import UI
 FILTER_REGEX = re.compile(
     '^(array|book|box|bulin|cat'
     '|chip|coin|cube|drill|food'
-    '|plate|retrofit|pr|dr|specializedcore'
+    '|plate|retrofit|pr|dr|specializedcore|unget'
     '|logger|tuning'
     '|type93pureoxygentorpedo|type1armorpiercingshell|superheavyshell'
     '|hecombatplan|fragment|hiddenzonedatalogger'

--- a/module/shop/shop_merit.py
+++ b/module/shop/shop_merit.py
@@ -1,9 +1,52 @@
+import cv2
+
 from module.base.decorator import cached_property
+from module.base.utils import color_similarity_2d
 from module.logger import logger
 from module.shop.base import ShopItemGrid, ShopItemGrid_250814
 from module.shop.clerk import ShopClerk
 from module.shop.shop_status import ShopStatus
 from module.shop.ui import ShopUI
+
+
+class ShopItemGrid_250814_Unget(ShopItemGrid_250814):
+    """
+    Shop item grid with unget ribbon detection for Merit Shop.
+
+    Items that haven't been obtained show a red ribbon at the top right of
+    the card. Ribbon overflows the 64px button, detection runs on the left
+    part of it which remains inside the 96x96 item image.
+    """
+
+    RIBBON_AREA = (56, 0, 96, 48)
+    UNGET_COLOR = (249, 91, 103)  # RGB, mean color of ribbon red
+    UNGET_SIMILARITY = 180
+    UNGET_COUNT = 50
+
+    def predict(self, image, name=True, amount=True, cost=False, price=False, tag=False):
+        items = super().predict(image, name, amount, cost, price, tag)
+        for item in items:
+            if self.predict_ribbon(item):
+                logger.info(f'Item {item} has unget ribbon, rename to Unget')
+                item.name = 'Unget'
+                item.group = 'unget'
+        return items
+
+    def predict_ribbon(self, item):
+        """
+        Count pixels similar to ribbon red at the top right corner of item image.
+
+        Args:
+            item (Item):
+
+        Returns:
+            bool: If unget ribbon detected.
+        """
+        x1, y1, x2, y2 = self.RIBBON_AREA
+        roi = item.image[y1:y2, x1:x2]
+        mask = color_similarity_2d(roi, color=self.UNGET_COLOR)
+        cv2.inRange(mask, self.UNGET_SIMILARITY, 255, dst=mask)
+        return cv2.countNonZero(mask) > self.UNGET_COUNT
 
 
 class MeritShop_250814(ShopClerk, ShopUI, ShopStatus):
@@ -25,7 +68,7 @@ class MeritShop_250814(ShopClerk, ShopUI, ShopStatus):
             ShopItemGrid:
         """
         shop_grid = self.shop_grid
-        shop_merit_items = ShopItemGrid_250814(
+        shop_merit_items = ShopItemGrid_250814_Unget(
             shop_grid,
             templates={},
             template_area=(25, 20, 82, 72),


### PR DESCRIPTION
## 动机
Fixes #5932
## 方案
未获取图案是右上角固定位置、固定颜色的纯色 UI 元素，采用颜色检测（color_similarity_2d + 像素计数，与 predict_tag / image_color_count 同模式）
检测区域取卡片右上角在 64px 按钮内的稳定部分，仅影响军需商店（勋章/公会/核心/通用商店仍使用原 ShopItemGrid_250814）。

## 使用
opt-in：军需商店过滤器加入 `Unget`（如 `Cube > Unget`，顺序即优先级）即生效，默认配置行为不变。

## 测试
<img width="1280" height="720" alt="matched_MuMu-20260824-204841-722" src="https://github.com/user-attachments/assets/c6fae1c8-9aef-4bb6-b6d8-c386dd10fe21" />
<img width="1280" height="720" alt="matched_MuMu-20260829-170727-906" src="https://github.com/user-attachments/assets/0f6e9aad-5ecb-4387-936b-b0e22b750490" />

## 已知限制
阈值基于 CN 服截图校准

